### PR TITLE
Use new blockstream explorer

### DIFF
--- a/general_funding.md
+++ b/general_funding.md
@@ -24,8 +24,8 @@ Last updated November 5th, 2018
 
 ## Bitcoin donation address:
 
-* bitcoin legacy [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/)
-* bitcoin segwit [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockchair.com/bitcoin/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65).
+* bitcoin legacy: [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://blockstream.info/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs)
+* bitcoin segwit: [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockstream.info/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65)
 
 Please note the 2nd address is a [Bech32 address](https://en.bitcoin.it/wiki/Bech32_adoption), so please ensure your wallet supports sending to a Bech32 address to use it. Many wallets and exchanges now support this, and you can [check adoption here](https://en.bitcoin.it/wiki/Bech32_adoption).
 

--- a/sec_audit.md
+++ b/sec_audit.md
@@ -8,8 +8,8 @@ TL;DR Grin is nearing its final phases of development before the release of
 its cryptocurrency network (mainnet). To do so safely, the Grin codebase needs
 to undergo a security audit. We're soliciting donations:
 
-* bitcoin legacy [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/)
-* bitcoin segwit [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockchair.com/bitcoin/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65).
+* bitcoin legacy [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://blockstream.info/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs)
+* bitcoin segwit [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockstream.info/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65).
 
 Status: Open
 

--- a/sec_audit.md
+++ b/sec_audit.md
@@ -8,8 +8,8 @@ TL;DR Grin is nearing its final phases of development before the release of
 its cryptocurrency network (mainnet). To do so safely, the Grin codebase needs
 to undergo a security audit. We're soliciting donations:
 
-* bitcoin legacy [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://blockstream.info/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs)
-* bitcoin segwit [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockstream.info/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65).
+* bitcoin legacy: [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://blockstream.info/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs)
+* bitcoin segwit: [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockstream.info/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65)
 
 Status: Open
 


### PR DESCRIPTION
Use new blockstream explorer for our funding addresses.

Pros:
* full bech32 address support (single explorer for both addresses)
* does not look like blockchair website

