### PR TITLE
recolor whatis- and github-buttons

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -13,3 +13,11 @@
     @content;
   }
 }
+
+$smiley-yellow: #fef102;
+$smiley-black: black;
+
+// bulma has some default colors (#ffdd57, ffd324, ffdb4a) which we've been using by default. They're almost, but not entirely, completely unlike tea^H^H^Hthe smiley yellow. (Tip: Uncomment and your editor might render the colors)
+// $bulma-warning: #ffdd57;
+// $bulma-warning-hover: #ffd324;
+// $bulma-warning-hover-background: #ffdb4a;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -125,3 +125,14 @@ ul li a {
 	max-height: 100%;
 	vertical-align: middle;
 }
+
+.hero-body .whatis {
+  margin-bottom: 9px;
+  border: 3px solid $smiley-yellow; // TODO: refactor: remove is-warning is-outlined
+  color: $smiley-yellow;
+}
+.hero-body .whatis:hover {
+  border-color: $smiley-black;
+  background-color: $smiley-yellow;
+  color: $smiley-black;
+}

--- a/index.md
+++ b/index.md
@@ -21,10 +21,10 @@ layout: default
           </h2>
           <br>
           <p class="has-text-centered" style="margin-top: -1rem;">
-          <a href="https://github.com/mimblewimble/grin/blob/master/doc/intro.md" class="button is-medium is-warning is-outlined">
+          <a href="https://github.com/mimblewimble/grin/blob/master/doc/intro.md" class="button is-medium is-outlined whatis">
             What's Mimblewimble?
           </a>
-          <a href="https://github.com/mimblewimble/grin" class="button is-medium is-warning is-outlined">
+          <a href="https://github.com/mimblewimble/grin" class="button is-medium is-outlined whatis">
             <i class="fab fa-github"></i>
           </a>
           </p>


### PR DESCRIPTION
I kept being irritated at the low contrast on the two buttons "What's Mimblewimble" and the github button just below the smiley logo, and experimented. This version, reusing the color and bold border / outline makes these buttons fit-in better together with the Grin logo, and I made the :hover style pop out even more with fully black borders. Feels more clickable and readable this way. Good or bad? I think it's at least better than before :)  