### PR TITLE
add Keybase

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -51,8 +51,11 @@
                 <a href="https://www.grin-forum.org/"><i class="fab fa-discourse"></i>Forum</a>
               </li>
               <li>
-                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord</a>
+                <a href="https://keybase.io/team/grincoin"><i class="fab fa-keybase"></i>Keybase chat & trade</a>
               </li>
+              <!-- <li>
+                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord</a>
+              </li> -->
               <li>
                 <a href="https://launchpad.net/~mimblewimble"><i class="fas fa-mail-bulk"></i>Mailing List</a>
               </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -42,7 +42,7 @@
             <h1 class="title">Get Involved</h1>
             <ul>
               <li>
-                <a href="https://gitter.im/grin_community/Lobby"><i class="fab fa-gitter"></i>Gitter</a>
+                <a href="https://gitter.im/grin_community/Lobby"><i class="fab fa-gitter"></i>Gitter (Lobby)</a>
               </li>
               <li>
                 <a href="https://twitter.com/grinmw"><i class="fab fa-twitter"></i>Twitter</a>
@@ -51,11 +51,11 @@
                 <a href="https://www.grin-forum.org/"><i class="fab fa-discourse"></i>Forum</a>
               </li>
               <li>
-                <a href="https://keybase.io/team/grincoin"><i class="fab fa-keybase"></i>Keybase chat & trade</a>
+                <a href="https://keybase.io/team/grincoin"><i class="fab fa-keybase"></i>Keybase chat</a>
               </li>
-              <!-- <li>
-                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord</a>
-              </li> -->
+              <li>
+                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord chat</a>
+              </li>
               <li>
                 <a href="https://launchpad.net/~mimblewimble"><i class="fas fa-mail-bulk"></i>Mailing List</a>
               </li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -51,10 +51,10 @@
                 <a href="https://www.grin-forum.org/"><i class="fab fa-discourse"></i>Forum</a>
               </li>
               <li>
-                <a href="https://keybase.io/team/grincoin"><i class="fab fa-keybase"></i>Keybase chat</a>
+                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord chat</a>
               </li>
               <li>
-                <a href="https://discord.gg/Z3sEfEU"><i class="fab fa-discord"></i>Discord chat</a>
+                <a href="https://keybase.io/team/grincoin"><i class="fab fa-keybase"></i>Keybase chat</a>
               </li>
               <li>
                 <a href="https://launchpad.net/~mimblewimble"><i class="fas fa-mail-bulk"></i>Mailing List</a>


### PR DESCRIPTION
prioritise linking to Keybase, since it is supported for grin wallet transactions, and because we have enough eyes on that chat to quickly kick out spammers/scammers