### PR TITLE
reworked https://github.com/mimblewimble/site/pull/73 for new site de…

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ layout: default
     </header>
     <section id="status">
       <span class="status-text">
-        Currently Live: Main Net
+        Currently Live: mainnet
       </span>
       <span class="status-message">
         Grin was launched on <a href="https://github.com/mimblewimble/grin/commit/8fc489a80868fcf12fcdbc0551528bb73fc891a0">Jan. 15th 2019</a>. It's very young and experimental. Use at your own risk!
@@ -97,16 +97,16 @@ layout: default
       </div>
       <a href="https://github.com/mimblewimble/docs/wiki/Getting-Started-With-Grin%3A-Links-and-Resources">
         <div class="info-box">
-          <h4>Main Net, Onwards!</h4>
-          <p>Grin Main Net was launched on Jan. 15 2019.</p>
+          <h4>mainnet, Onwards!</h4>
+          <p>Grin mainnet was launched on Jan. 15 2019.</p>
           <p>Get started here!</p>
           <span class="info-learn-more">Learn more</span>
         </div>
       </a>
       <a href="https://github.com/mimblewimble/grin/blob/master/doc/build.md">
         <div class="info-box">
-          <h4>Floonet</h4>
-          <p>Floonet is Grin’s official testnet. We need your help testing: either compile from the source or download the grin binary and join us.</p>
+          <h4>floonet, Upwards!</h4>
+          <p>Grin floonet is our official testnet. We need your help testing: either compile from the source or download the grin binary and join us.</p>
           <span class="info-learn-more">Learn more</span>
         </div>
       </a>


### PR DESCRIPTION
Looks like #73 got blitzed when we rolled the latest site design out.

* "Main Net" -> "mainnet"
* "Floonet" -> "floonet"
* onwards! and upwards!

