### PR TITLE
removed discord, changed twitter to grincouncil

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,8 +23,7 @@
       <div><a href="https://gitter.im/grin_community/Lobby">Gitter</a></div>
       <div><a href="https://grinnews.substack.com/">News</a></div>
       <div><a href="https://www.grin-forum.org/">Forum</a></div>
-      <div><a href="https://twitter.com/grinmw">Twitter</a></div>
-      <div><a href="https://discord.gg/Z3sEfEU">Discord</a></div>
+      <div><a href="https://twitter.com/grincouncil">Twitter</a></div>
       <div><a href="https://launchpad.net/~mimblewimble">Mailing List</a></div>
       <div><a href="/page-contribution-howto">Improve this website</a></div>
     </section>


### PR DESCRIPTION
ideally @grincouncil twitter would follow @grinmw.
maybe @grinmw deserves official page listing since it is a narrow  band and we have a couple council members moderating, but I can't in clear conscience let the discord be listed as official (I have already seen it referenced as such) when it is such an attack vector, and then at the same time try to pass my twitter as official. would be an honor, but if that's what it takes to remove the discord official link then it must be done.