### PR TITLE
change twitter to grincouncil, remove discord link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,8 +23,7 @@
       <div><a href="https://gitter.im/grin_community/Lobby">Gitter</a></div>
       <div><a href="https://grinnews.substack.com/">News</a></div>
       <div><a href="https://www.grin-forum.org/">Forum</a></div>
-      <div><a href="https://twitter.com/grinmw">Twitter</a></div>
-      <div><a href="https://discord.gg/Z3sEfEU">Discord</a></div>
+      <div><a href="https://twitter.com/grincouncil">Twitter</a></div>
       <div><a href="https://launchpad.net/~mimblewimble">Mailing List</a></div>
       <div><a href="/page-contribution-howto">Improve this website</a></div>
     </section>


### PR DESCRIPTION
I have already seen the discord referenced as official in other channels (and a random opinion from the discord touted as official), and I think it is too wide an attack surface and liability to have it listed on the main site. it is a great community, but lots of trash talking, etc. would be too easy for it to be comandeered and used to pitch scams or alternative projects. the intentions of the speculators who founded and moderate the channel are not as pure as the core grin team, and the link on the main grin site does not reflect this fact.

I would love for my twitter @grinmw to be listed as official, but can't in clear conscience have it, as technically an unofficial channel, listed on the main site but deny the right of the discord. the twitter is narrow band and has a couple of core members with full moderating permissions (@lehnberg and @yeastplume), so it might be seen as less of a liabilty, but still gives undue power to someone not on the council (me.. which could  be seen as a plus but what if I lose my mind or die). would love if the "official" twitter followed the grinmw account though. and if others think it's deserving so be it, but the discord cannot be listed on the main page in my opinion. it is already listed elsewhere on the wiki I believe, which is appropriate and productive.