### PR TITLE
Rename Gitter to Chat, link to MP

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,7 +16,7 @@
           <span class="dropdown-heading">Everyone.</span>
           <a href="https://grinnews.substack.com/">News</a>
           <a href="https://www.grin-forum.org/">Forum</a>
-          <a href="https://gitter.im/grin_community/Lobby">Gitter</a>
+          <a href="https://gitter.im/grin_community/Lobby">Chat</a>
         </nav>
       </span>
     </li>
@@ -40,6 +40,7 @@
           <a href="https://github.com/mimblewimble/grin/blob/master/doc/pow/pow.md">Cuckoo cycle</a>
           <a href="https://github.com/mimblewimble/grin/blob/master/doc/grin4bitcoiners.md">Grin for Bitcoiners</a>
           <a href="https://github.com/mimblewimble/docs/wiki/Grin-Privacy-Primer">Privacy in Grin</a>
+          <a href="https://github.com/mimblewimble/docs/wiki/Monetary-Policy">Monetary Policy</a>
           <a href="https://github.com/mimblewimble/docs/wiki/Community-projects">Community projects</a>
           <a href="funding">Community funding</a>
           <a href="friends">Friends of Grin</a>


### PR DESCRIPTION
I think the MP doc is important enough to not let it burried inside the wiki

Also "Chat" makes more sense that "Gitter" to most newcomers.