### PR TITLE
fix: Grin-pool.org is needed in entities, to match income_log.csv

### DIFF
--- a/assets/csv/entities.csv
+++ b/assets/csv/entities.csv
@@ -30,3 +30,4 @@ id,name,href,profile_src,description
 29,Minerbabe,https://www.minerbabe.com,assets/images/logos/minerbabe-white.png,
 30,Sparkpool,https://www.sparkpool.com,assets/images/logos/Sparkpool-660x.png,
 31,Aurel,https://keybase.io/aurel,assets/images/logos/aurel.jpg,I am a strong supporter of privacy and human rights.
+32,Grin-pool.org,https://grin-pool.org/,,


### PR DESCRIPTION
```
Gary Yu @garyyu 12:21
@nijynot the https://grin-tech.org/friends becomes empty Hall of Fame after I merged mimblewimble/grin-pm#79
Could you please take a look the problem? thanks

nijynot @nijynot 21:17
@garyyu Found the problem. "Grin-pool.org" is not added in entities.csv, so it'll not render correctly.
If a new donation is added to the income_log.csv, then it's source must already exists as a to a row in entities.csv for it to work, if that makes sense.
We should probably move entities.csv over to grin-pm to make it easier to change/add.

Gary Yu @garyyu 21:19
thanks @nijynot
the situation is grin-pool.org’s donation don’t reach the threshold to be displayed in Friends of Grin (1,000 US$ for org).
if I add it into entities.csv, would you show it automatically into logos area?

nijynot @nijynot 21:21
Ah, I see. That part of the site has actually not been automized as it would require us to add $1,000 to every other company in the logos area.

Gary Yu @garyyu 21:22
Okay, understand. So, atm, I can modify entities.csv to make them match  thanks

nijynot @nijynot 21:22
So companies/individuals still has to be added by hand in HTML. Could work on a PR for that to automize it, but many rows of $1,000 will needed to be added income_log.csv
Only leaderboard/hall of fame updates automatically.

Gary Yu @garyyu 21:24
Could work on a PR for that to automize it, but many rows of $1,000 will needed to be added income_log.csv
 understand. we can keep it like this for a while. After the income_log.csv has enough info, we can switch to automize.

```