### PR TITLE
linkify urls in donation comments

### DIFF
--- a/_sass/friends.scss
+++ b/_sass/friends.scss
@@ -147,10 +147,16 @@
   }
 }
 .leaderboard-row .donation {
-  padding-bottom: 4px;
-  line-height: 1.6em;
+  padding-bottom: $tiny;
+  line-height: 1.4em;
   &:last-child {
     padding-bottom: 0;
+  }
+  & a {
+    border-bottom: 1px solid black !important;
+  }
+  & a:hover {
+    border-bottom: 0 !important;
   }
 }
 .leaderboard-row .subheading {
@@ -162,7 +168,6 @@
 .leaderboard-row .data {
   flex: 1;
   padding-right: $small;
-  // flex-grow: 9;
 }
 .leaderboard-row .donation-number {
   font-weight: 600;

--- a/friends.html
+++ b/friends.html
@@ -268,7 +268,9 @@ layout: page
   }
 
   function parseCsv(csv) {
+    // Use trimHeaders <5.0.0, and transformHeader >=5.0.0
     return Papa.parse(csv, {
+      trimHeaders: true,
       header: true,
       skipEmptyLines: true,
     }).data;
@@ -466,7 +468,9 @@ layout: page
                 <div className="donation" key={donation.income_id + donation.source}>
                   <strong>{'$' + numberWithCommas(parseInt(donation.USD_equivalent)) + ' '}</strong>
                   ({donation.amount + ' ' + donation.currency}){': '}
-                  <span>{donation.comment}</span>
+                  {(donation.url && donation.url !== '-') ? (
+                    <a href={donation.url}>{donation.comment}</a>
+                  ) : <span>{donation.comment}</span>}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
URLs in donation comments will turn into links.
Using the [linkifyjs](https://github.com/SoapBox/linkifyjs) library to do this.

Does not sanitze, so open to XSS attacks.
Should not be a problem as long as `script` tags are not merged into the `income_log.csv` comment column.