### PR TITLE
fix: grinmint entry missing comma, correct logo url

### DIFF
--- a/assets/csv/entities.csv
+++ b/assets/csv/entities.csv
@@ -4,7 +4,7 @@ id,name,href,profile_src,description
 3,TMGOX,https://www.tmgox.com/,assets/images/logos/tmgox-logo.jpg,
 4,GPU.one,https://gpu.one/,assets/images/logos/gpuOne-white.png,
 5,Mega Pool,https://www.megapool.info,assets/images/logos/Mega-Pool-Logo-trans.png,
-6,Grinmint by BlockCypher,https://www.grinmint.com/img/grinmint_logo_square.svg,
+6,Grinmint by BlockCypher,https://www.grinmint.com/,assets/images/logos/grinmint_logo_square.svg,
 7,Kyokan,https://kyokan.io,assets/images/logos/kyokan_teal_white.png,
 8,Innosilicon,http://innosilicon.com,assets/images/logos/Innosilicon.png,
 9,Galleon,https://galleon.exchange,assets/images/logos/galleon.png,


### PR DESCRIPTION
this PR:
* fixes a comma typo slipped in as part of #120 that broke the CSV table; and
* points the grinmint logo to the asset uploaded as part of #120