### PR TITLE
Add first HF warning banner

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,0 +1,5 @@
+<div class="warning-banner">
+    <a href="https://www.grin-forum.org/t/grin-first-hard-fork-mid-july/5148" target="_blank">IMPORTANT UPDATE: On
+        block
+        #262,080, Grin will hard fork. Click this banner for more information.</a>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js" integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
   </head>
   <body>
+    {% include banner.html %}
     <header class="container">
       {% include navigation.html %}
     </header>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -91,3 +91,19 @@ li {
     padding: 32px;
   }
 }
+.warning-banner {
+  align-items: center;
+  border-radius: 4px;
+  background-color: #e74c3c;
+  box-shadow: 0 10px 45px -12px rgba(93, 90, 50, 0.25), 0 18px 36px -18px rgba(0, 0, 0, .3);
+  display: flex;
+  height: 50px;
+  justify-content: center;
+}
+
+.warning-banner a {
+  border-bottom: 1px solid #e74c3c;
+  color: white;
+  margin-left: 10px;
+  margin-right:10px;
+}


### PR DESCRIPTION
As specified [here](https://www.grin-forum.org/t/grin-first-hard-fork-mid-july/5148).

Looks like this:
<img width="1680" alt="Capture d’écran 2019-06-10 à 10 13 08" src="https://user-images.githubusercontent.com/11842328/59201452-79edd480-8b68-11e9-8730-cc51c2215f82.png">
