### PR TITLE
Add download links for 2.0.0 in warning banner

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,5 +1,5 @@
 <div class="warning-banner">
-    <a href="https://www.grin-forum.org/t/grin-first-hard-fork-mid-july/5148" target="_blank">IMPORTANT UPDATE: On
-        block
-        #262,080, Grin will hard fork. Click this banner for more information.</a>
+    <a href="https://www.grin-forum.org/t/grin-first-hard-fork-mid-july/5148" target="_blank">IMPORTANT UPDATE: On block #262,080, Grin will hard fork. Please upgrade your node to <object><a target="_blank" href="https://github.com/mimblewimble/grin/releases/tag/v2.0.0">Grin v2.0.0</a></object> and wallet to <object><a target="_blank" href="https://github.com/mimblewimble/grin-wallet/releases/tag/v2.0.0">Grin-Wallet 2.0.0</a></object>. Click this banner for more information.</a>
+    
+    
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -101,9 +101,14 @@ li {
   justify-content: center;
 }
 
-.warning-banner a {
+.warning-banner > a {
   border-bottom: 1px solid #e74c3c;
   color: white;
-  margin-left: 10px;
-  margin-right:10px;
+  margin: 10px;
+}
+
+.warning-banner a object a {
+  border-bottom: 1px solid white;
+  margin-left: 0px;
+  margin-right:0px;
 }


### PR DESCRIPTION
Looks like this:
<img width="1675" alt="Capture d’écran 2019-07-09 à 09 50 05" src="https://user-images.githubusercontent.com/11842328/60869279-f559a900-a22e-11e9-8042-2ac7b1357e42.png">
