### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-grin-tech.org
+mimblewimble.github.io/site


### PR DESCRIPTION
right now the github site is redirecting to grin-tech.org apparently, but if it were not it then mimblewimble.github.io would resolve correctly and I, or anyone else, could forward their domain to that address. I'm not sure that just changing this file will do it but I don't see what else it's doing.