### PR TITLE
Do not display donation addresses directly on website

### DIFF
--- a/fund.html
+++ b/fund.html
@@ -16,11 +16,11 @@ layout: default-black
     </p>
     <h3>Donate</h3>
     <small class="fund-donation-type">GRIN DONATION ADDRESS</small>
-    <a href="https://council-donations.yeastplume.org/" class="fund-address">https://council-donations.yeastplume.org</a>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#grin" class="fund-address">Address in /grin-pm repo</a>.
     <small class="fund-donation-type">BITCOIN LEGACY</small>
-    <a href="https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/" class="fund-address">3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs</a>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#legacy" class="fund-address">Address in /grin-pm repo</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>
-    <a href="https://blockchair.com/bitcoin/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65" class="fund-address">bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65</a>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#segwit" class="fund-address">Address in /grin-pm repo</a>
     <p>Note that the Bitcoin Segwit address is a Bech32 address. Please ensure your wallet supports sending to a Bech32 address before you use it. Many wallets and exchanges now support it, you can check adoption here.</p>
     <small class="fund-donation-type">ETHEREUM</small>
     <span class="fund-closed">Ethereum donations are suspended temporarily, and will be operational again as soon as possible.</span>

--- a/fund.html
+++ b/fund.html
@@ -21,7 +21,7 @@ layout: default-black
     <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#legacy" class="fund-address">Address in /grin-pm repo</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>
     <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#segwit" class="fund-address">Address in /grin-pm repo</a>
-    <p>Note that the Bitcoin Segwit address is a Bech32 address. Please ensure your wallet supports sending to a Bech32 address before you use it. Many wallets and exchanges now support it, you can check adoption here.</p>
+    <p>Note that the Bitcoin Segwit address is a Bech32 address. Please ensure your wallet supports sending to a Bech32 address before you use it. Many wallets and exchanges now support it, you can check adoption <a href="https://en.bitcoin.it/wiki/Bech32_adoption">here</a>.</p>
     <small class="fund-donation-type">ETHEREUM</small>
     <span class="fund-closed">Ethereum donations are suspended temporarily, and will be operational again as soon as possible.</span>
     <small class="fund-donation-type">ZCASH</small>

--- a/sec_audit.md
+++ b/sec_audit.md
@@ -15,15 +15,13 @@ layout: page
 
 **The grin security audit funding campaign was completed on December 20th 2018. Thank you to all who generously donated!**
 
+**UPDATE 2019-10-23: The report and findings have now been published: https://www.grin-forum.org/t/grin-security-audit-2-results/6264**
+
 TL;DR Grin is nearing its final phases of development before the release of
 its cryptocurrency network (mainnet). To do so safely, the Grin codebase needs
-to undergo a security audit. We're soliciting donations:
+to undergo a security audit.
 
-- bitcoin legacy [3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs](https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/){:.address-link}
-- bitcoin segwit [bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65](https://blockchair.com/bitcoin/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65){:.address-link}
-- zcash t-address [t1QGYYXan3HHEuiPEfccKnUuWEP4CsVvPA5](https://explorer.zcha.in/accounts/t1QGYYXan3HHEuiPEfccKnUuWEP4CsVvPA5){:.address-link}
-
-Status: Open
+Status: Closed
 
 Goal: {{target_amount | round}} BTC
 

--- a/yeastplume.md
+++ b/yeastplume.md
@@ -6,7 +6,7 @@ layout: page
 
 Funding to allow Yeastplume to give full-time attention to Grin from March-Aug 2019
 
-## Funding status (March - Aug 2019)
+## Funding status (March - Aug 2019) - CLOSED
 
 Status: Goal Met - €66,580 of €55,000 Target
 Goal: Crypto equivalent of €55,000
@@ -19,14 +19,13 @@ Raised (amounts as of Feb 3rd, 2019):
 - ~€66,580 Total
 
 ## Bitcoin donation address:
-[3B3qq3EAPtpkSoGHSDfY6rxpK5Bqh7zmij](https://blockchain.info/address/3B3qq3EAPtpkSoGHSDfY6rxpK5Bqh7zmij)
+`no longer active`
 
 ## Ethereum donation address:
-[0xeFC76886E5C50D1FD15addAbb59D2D3582A03A61](https://etherscan.io/address/0xeFC76886E5C50D1FD15addAbb59D2D3582A03A61)
+`no longer active`
 
 ## Grin Donations! (Experimental, let's see what happens!)
-* Via [wallet713](https://github.com/vault713/wallet713) - gVtiAMLJLHQB1HyjfoFKdkk2jHsRQ2uJC4zbhcVJWBKCii6ehoqq
-* Or send a Slate to: yeastplume@protonmail.com
+`no longer active`
 
 ## Source for this page (via https):
 


### PR DESCRIPTION
Fixes #151.
Blocked by https://github.com/mimblewimble/grin-pm/pull/209.

Also:
- Adds link to the security adit results on the audit page of the website, and sets its funding status to closed.
- Fixes a link to segwit adoption comparison table.
- Removes old Yeastplume donation addresses.
