### PR TITLE
Update Landing Page / Remove Bad Donation Address

### DIFF
--- a/fund.html
+++ b/fund.html
@@ -15,8 +15,6 @@ layout: default-black
       Donate to the General Fund to show up on the <a href="/friends">Friends of Grin</a> page.
     </p>
     <h3>Donate</h3>
-    <small class="fund-donation-type">GRIN DONATION ADDRESS</small>
-    <a href="https://council-donations.yeastplume.org/" class="fund-address">https://council-donations.yeastplume.org</a>
     <small class="fund-donation-type">BITCOIN LEGACY</small>
     <a href="https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/" class="fund-address">3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
       <div>
         <span class="section-1-grin">GRiN</span>
         <span class="section-1-v">v</span>
-        <span class="section-1-version">2.0.0</span>
+        <span class="section-1-version">2.1.0</span>
       </div>
       <p class="section-1-text">Electronic transactions for all.
         Without censorship or restrictions.


### PR DESCRIPTION
It seems like the release version is a unnecessary detail to keep in sync and updated so prominently on the main landing page.  Having the version incorrect (as it currently is) causes significant legitimacy issues for the new grin.mw website.  As a non-controversial temporary fix... this pull request fixes the version number.  As a long term solutions, I recommend removing this detail from the landing page.

The 'Grin Donation Address' led to a yeastplume.org page which is invalid. Suggest any replacement method be self hosted on grin.mw.