### PR TITLE
Fix broken forum link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
       <a href="https://grin.mw">https://grin.mw</a>
     </p>
     <div class="footer-links">
-      <a href="https://grin-forum.org">Forum</a>
+      <a href="https://www.grin-forum.org">Forum</a>
       <a href="https://gitter.im/grin_community/Lobby">Gitter</a>
       <a href="https://grinnews.substack.com/">News</a>
       <a href="https://twitter.com/grinmw">Twitter</a>


### PR DESCRIPTION
as reported by b33rkeg:

> Hi, I see you are working on the website. I can't log in Github atm but the forum button in the footer redirects to https://grin-forum.org which is not working, but https://www.grin-forum.org works.