### PR TITLE
Add sticky warning footer for HF2

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,11 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/main.css" />
   </head>
   <body>
+    <div class="warning-footer">
+      <a href="https://www.grin-forum.org/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
+          block
+          #524,160, Grin will hard fork. Click this banner for more information.</a>
+    </div>
     <div id="fullscreen-menu" class="nav-hamburger-fullscreen">
       <a href="."><h2>Index</h2></a>
       <a href="get-started"><h2>Get Started</h2></a>
@@ -41,6 +46,11 @@
     </header>
     {{ content }}
     {% include footer.html %}
+    <div class="warning-footer">
+      <a href="https://www.grin-forum.org/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
+          block
+          #524,160, Grin will hard fork. Click this banner for more information.</a>
+    </div>
     <script type="text/javascript">
       var logo = document.getElementById('grin-logo-bare');
       var fullLogo = document.getElementById('grin-logo-full-svg');

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -140,3 +140,25 @@ li {
 
 @media (max-width: 768px) {
 }
+
+.warning-footer a {
+  border-bottom: 1px solid #e74c3c;
+  color: white;
+  margin-left: 10px;
+  margin-right:10px;
+}
+
+.warning-footer {
+  position: fixed;
+  justify-content: center;
+  box-shadow: 0 10px 45px -12px rgba(93, 90, 50, 0.25), 0 18px 36px -18px rgba(0, 0, 0, .3);
+  left: 0;
+  align-items: center;
+  display: flex;
+  bottom: 0;
+  width: 100%;
+  height: 50px;
+  background-color: #e74c3c;
+  color: white;
+  text-align: center;
+}


### PR DESCRIPTION
Somehow a bit more sketchy to add a top banner warning. 
So instead it's a sticky red warning footer which does the job too.
Screenshot:
<img width="1792" alt="Capture d’écran 2019-12-18 à 09 55 06" src="https://user-images.githubusercontent.com/11842328/71096615-a2403680-217c-11ea-9b7a-9b08d035c714.png">
