### PR TITLE
Add community page with Keybase how-to

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -12,6 +12,7 @@
   <ul class="nav-list">
     <li><a href="get-started">Get Started</a></li>
     <li><a href="download">Download</a></li>
+    <li><a href="community">Community</a></li>
     <li><a href="friends">Friends of Grin</a></li>
     <li><a href="fund">General Fund</a></li>
     <li><a href="open-research-problems">Research</a></li>

--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -20,6 +20,7 @@
       <a href="."><h2>Index</h2></a>
       <a href="get-started"><h2>Get Started</h2></a>
       <a href="download"><h2>Download</h2></a>
+      <a href="community"><h2>Community</h2></a>
       <a href="friends"><h2>Friends of Grin</h2></a>
       <a href="fund"><h2>General Fund</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
       <a href="."><h2>Index</h2></a>
       <a href="get-started"><h2>Get Started</h2></a>
       <a href="download"><h2>Download</h2></a>
+      <a href="community"><h2>Community</h2></a>
       <a href="friends"><h2>Friends of Grin</h2></a>
       <a href="fund"><h2>General Fund</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>

--- a/_sass/_markdown.scss
+++ b/_sass/_markdown.scss
@@ -93,30 +93,30 @@ hr {
 //   overflow-x: auto;
 //   /* overflow-x: hidden; */
 // }
-// pre > code {
-//   position: inherit;
-//   background-color: transparent;
-//   border-radius: 0;
-//   font-family: monospace;
-//   font-size: 13px;
-//   padding: 0;
-//   top: 0;
-//   line-height: 18px;
-// }
-// code {
-//   position: relative;
-//   background-color: #222;
-//   border-radius: 4px;
-//   color: #eee;
-//   font-family: monospace;
-//   font-size: 13px;
-//   padding: 2px 4px;
-//   top: -1px;
-// }
-// code.inverted {
-//   background-color: #e9e9e9;
-//   color: black;
-// }
+pre > code {
+  position: inherit;
+  background-color: transparent;
+  border-radius: 0;
+  font-family: monospace;
+  font-size: 13px;
+  padding: 0;
+  top: 0;
+  line-height: 18px;
+}
+code {
+  position: relative;
+  background-color: #222;
+  border-radius: 4px;
+  color: #eee;
+  font-family: monospace;
+  font-size: 13px;
+  padding: 2px 4px;
+  top: -1px;
+}
+code.inverted {
+  background-color: #e9e9e9;
+  color: black;
+}
 // kbd {
 //   background-color: #fafbfc;
 //   border: solid 1px #d1d5da;

--- a/community.md
+++ b/community.md
@@ -1,0 +1,34 @@
+---
+layout: page
+---
+
+# Get involved in Grin's community
+<br>
+
+## Keybase Chat
+The main place for real time and asynch communication. End to end encrypted, works over TOR, and supports command line. [Grincoin team on keybase↗](https://https://keybase.io/team/grincoin)
+
+### Bi-weekly meetings
+* every tuesday, at 15:00 [UTC](http://www.timebie.com/std/utc.php).
+* **development** topics one week, in the **grincoin#dev** channel.
+* **governance** topics the other week, in the **grincoin#general** channel.
+* open for all.
+* documented in the /grin-pm github repo:
+   * [upcoming meetings & agendas↗](https://github.com/mimblewimble/grin-pm/issues?q=is%3Aissue+is%3Aopen+label%3Ameetings)
+   * [previous meeting notes↗](https://github.com/mimblewimble/grin-pm#meeting-notes)
+
+### How to join
+1. Install and setup keybase.
+2. Join the grin community:
+   * **From the app:** Select "Teams" >> "Join a team" and then type "grincoin"
+   * **From the command line:** `keybase team request-access grincoin`   
+<br>
+
+## Grin Forum
+
+Longer form writing in the forum with the most comprehensive list of Grin & Mimblewimble related topics and thoughts: [https://grin-forum.org](https://grin-forum.org)
+<br>
+
+## Mailing List
+
+Focused on development, the [Mimblewimble mailing list↗](https://lists.launchpad.net/mimblewimble/) offers insight into the evolution of the protocol and some of the motivations behind the project's design decisions.


### PR DESCRIPTION
### Description
Following an [action point in the last dev meeting](https://github.com/mimblewimble/grin-pm/blob/master/notes/20191217-meeting-governance.md#5-switch-meeting-location-from-gitter-to-keybase), this PR adds a `Community` section to the website with:
* links to Keybase, forum, and mailing list
* information about how to join the main keybase team
* information about the bi-weekly meetings and links to meeting notes and agendas

### Preview
![community](https://i.ibb.co/GdHJ5Dd/community.png)

