### PR TITLE
fix: linux grin-wallet download url

### DIFF
--- a/download.html
+++ b/download.html
@@ -63,7 +63,7 @@ layout: default
 
       <div id="Linux" class="tabcontent">
         <h3> <a
-            href="https://github.com/mimblewimble/grin/releases/download/v2.1.1/grin-v2.1.1-linux-amd64.tar.gz">grin-wallet
+            href="https://github.com/mimblewimble/grin-wallet/releases/download/v2.1.0/grin-wallet-v2.1.0-linux-amd64.tar.gz">grin-wallet
             v2.1.0</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">


### PR DESCRIPTION
fixes #173 

The download URL for `grin-wallet v2.1.0` for linux links to `grin v2.1.1`. This PR corrects it. Checksums have been verified to be correct.