### PR TITLE
add Governance section

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -13,6 +13,7 @@
     <li><a href="get-started">Get Started</a></li>
     <li><a href="download">Download</a></li>
     <li><a href="community">Community</a></li>
+    <li><a href="governance">Governance</a></li>
     <li><a href="friends">Friends of Grin</a></li>
     <li><a href="fund">General Fund</a></li>
     <li><a href="open-research-problems">Research</a></li>

--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -21,6 +21,7 @@
       <a href="get-started"><h2>Get Started</h2></a>
       <a href="download"><h2>Download</h2></a>
       <a href="community"><h2>Community</h2></a>
+      <a href="governance"><h2>Governance</h2></a>
       <a href="friends"><h2>Friends of Grin</h2></a>
       <a href="fund"><h2>General Fund</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,7 @@
       <a href="get-started"><h2>Get Started</h2></a>
       <a href="download"><h2>Download</h2></a>
       <a href="community"><h2>Community</h2></a>
+      <a href="governance"><h2>Governance</h2></a>
       <a href="friends"><h2>Friends of Grin</h2></a>
       <a href="fund"><h2>General Fund</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>

--- a/_sass/governance.scss
+++ b/_sass/governance.scss
@@ -21,9 +21,10 @@
     border-width: 0.2rem;
 }
 
-.team-table-avatar-link {
-    border-bottom: 0px;
-    
+.team-table-avatar.inactive {
+    -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+    filter: grayscale(100%);
+    border-color: #757575;
 }
 
 .team-table-details {
@@ -44,6 +45,14 @@
 .team-table-text {
     padding: 0rem;
     margin: 0rem;
+}
+
+.team-table-title.inactive {
+    color: #757575;
+}
+
+.team-table-text.inactive {
+    color: #757575;
 }
 
 .codebox {

--- a/_sass/governance.scss
+++ b/_sass/governance.scss
@@ -1,0 +1,60 @@
+.team-table {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 100%;
+    justify-content: flex-start;
+}
+
+.team-table-member {
+    display: flex;
+    width: 25rem;
+    padding-right: 1rem;
+    padding-bottom: 1rem;
+}
+
+.team-table-avatar {
+    padding: 0px;
+    width: 6rem;
+    height: 6rem;
+    border-style: solid;
+    border-width: 0.2rem;
+}
+
+.team-table-avatar-link {
+    border-bottom: 0px;
+    
+}
+
+.team-table-details {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    padding-left: 1rem;
+    margin: 0rem;
+}
+
+.team-table-title {
+    font-size: large;
+    font-weight: bold;
+    padding: 0rem;
+    margin: 0rem;
+}
+
+.team-table-text {
+    padding: 0rem;
+    margin: 0rem;
+}
+
+.codebox {
+  padding: 15px;
+  height: auto;
+  background: #2a2827;
+  color: #f7f7f7;
+  line-height: 1.5;
+}
+
+.codebox-heading {
+  margin-top: 10px;
+  margin-bottom:10px;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -10,6 +10,7 @@
 @import 'footer';
 @import 'fund';
 @import 'friends';
+@import 'governance';
 @import 'markdown';
 @charset 'utf-8';
 html, body {

--- a/governance.md
+++ b/governance.md
@@ -43,11 +43,11 @@ Project direction, sub-teams, security, general fund, cross-cutting concerns.
         </div>
     </div>
     <div class="team-table-member">
-        <a href="http://github.com/ignopeverell" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/ignopeverell" class="team-table-avatar"></a>
+        <img src="https://avatars.githubusercontent.com/ignopeverell" class="team-table-avatar inactive">
         <div class="team-table-details">
-            <p class="team-table-title">Ignotus Peverell</p>
-            <p class="team-table-text">github: <a href="http://github.com/ignopeverell">ignopeverell↗</a></p>
-            <p class="team-table-text">keybase: <a href="https://keybase.io/ignotus">@ignotus↗</a></p>
+            <p class="team-table-title inactive">Ignotus Peverell</p>
+            <p class="team-table-text inactive">github: ignopeverell</p>
+            <p class="team-table-text inactive">keybase: @ignotus</p>
         </div>
     </div>
     <div class="team-table-member">

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,100 @@
+---
+layout: page
+---
+
+# Governance
+<br>
+
+## RFC and governance processes
+
+Grin's [Request For Comments (RFC) process↗](https://github.com/mimblewimble/grin-rfcs/blob/master/text/0001-rfc-process.md) intends to provide a consistent and controlled path for substantial improvements to be made to Grin. Smaller changes, such as bug fixes and documentation improvements, can be implemented and reviewed via the normal GitHub pull request workflow. More major or complex changes can benefit from a more formal process to build consensus among Grin community participants and stakeholders.
+
+The RFC process was used to [evolve Grin's governance↗](https://github.com/mimblewimble/grin-rfcs/blob/master/text/0002-grin-governance.md), defining community principles and the core and sub-team structures. The [grin-rfcs repo↗](https://github.com/mimblewimble/grin-rfcs) contains all active RFCs.
+<br>
+
+## Active teams
+
+### Core team
+Project direction, sub-teams, security, general fund, cross-cutting concerns.
+
+<div class="team-table">
+    <div class="team-table-member">
+        <a href="http://github.com/hashmap" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/hashmap" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Alexey Miroshkin</p>
+            <p class="team-table-text">github: <a href="http://github.com/hashmap">hashmap↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/hashmap">@hashmap↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/antiochp" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/antiochp" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Antioch Peverell</p>
+            <p class="team-table-text">github: <a href="http://github.com/antiochp">antiochp↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/antiochp">@antiochp↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/lehnberg" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/lehnberg" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Daniel Lehnberg</p>
+            <p class="team-table-text">github: <a href="http://github.com/lehnberg">lehnberg↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/lehnberg">@lehnberg↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/ignopeverell" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/ignopeverell" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Ignotus Peverell</p>
+            <p class="team-table-text">github: <a href="http://github.com/ignopeverell">ignopeverell↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/ignotus">@ignotus↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/jaspervdm" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/jaspervdm" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Jasper van der Maarel</p>
+            <p class="team-table-text">github: <a href="http://github.com/jaspervdm">jaspervdm↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/jaspervdm">@jaspervdm↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/tromp" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/tromp" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">John Tromp</p>
+            <p class="team-table-text">github: <a href="http://github.com/tromp">tromp↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/tromp">@tromp↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/yeastplume" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/yeastplume" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Michael Cordner</p>
+            <p class="team-table-text">github: <a href="http://github.com/yeastplume">yeastplume↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/yeastplume">@yeastplume↗</a></p>
+        </div>
+    </div>
+    <div class="team-table-member">
+        <a href="http://github.com/quentinlesceller" style="border-bottom: 0px ! important;"><img src="https://avatars.githubusercontent.com/quentinlesceller" class="team-table-avatar"></a>
+        <div class="team-table-details">
+            <p class="team-table-title">Quentin Le Sceller</p>
+            <p class="team-table-text">github: <a href="http://github.com/quentinlesceller">quentinlesceller↗</a></p>
+            <p class="team-table-text">keybase: <a href="https://keybase.io/quentinlesceller">@quentinlesceller↗</a></p>
+        </div>
+    </div>
+</div>
+<br>
+
+### Node development team
+Protocol and consensus layer, proof of work, [grin↗](http://github.com/mimblewimble/grin) and [grin-miner↗](http://github.com/mimblewimble/grin-miner) repositories.
+* Team lead: @antiochp
+* Open for all, discussion on keybase: grincoin.teams.node_dev
+* **Join from the command line:** `keybase team request-access grincoin.teams.node_dev`
+<br>
+
+### Wallet development team
+Transaction building, wallet and associated libraries, [grin-wallet↗](http://github.com/mimblewimble/grin-wallet) repository.
+
+* Team lead: @yeastplume
+* Open for all, discussion on keybase: grincoin.teams.wallet_dev
+* **Join from the command line:** `keybase team request-access grincoin.teams.wallet_dev`


### PR DESCRIPTION
### Description
This PR introduces a governance section on the website, which provides:
* info on Grin's RFC and governance processes
* info about to the core, node, and wallet teams

### Live preview
https://lehnberg.net/site/governance

### Image preview
![preview](https://i.ibb.co/n1705sF/governance.png)
