### PR TITLE
Introduce Funding section

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -14,8 +14,7 @@
     <li><a href="download">Download</a></li>
     <li><a href="community">Community</a></li>
     <li><a href="governance">Governance</a></li>
-    <li><a href="friends">Friends of Grin</a></li>
-    <li><a href="fund">General Fund</a></li>
+    <li><a href="fund">Funding</a></li>
     <li><a href="open-research-problems">Research</a></li>
     <li><a href="https://github.com/mimblewimble/grin">GitHub</a></li>
   </ul>

--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -22,8 +22,7 @@
       <a href="download"><h2>Download</h2></a>
       <a href="community"><h2>Community</h2></a>
       <a href="governance"><h2>Governance</h2></a>
-      <a href="friends"><h2>Friends of Grin</h2></a>
-      <a href="fund"><h2>General Fund</h2></a>
+      <a href="fund"><h2>Funding</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,8 +27,7 @@
       <a href="download"><h2>Download</h2></a>
       <a href="community"><h2>Community</h2></a>
       <a href="governance"><h2>Governance</h2></a>
-      <a href="friends"><h2>Friends of Grin</h2></a>
-      <a href="fund"><h2>General Fund</h2></a>
+      <a href="fund"><h2>Funding</h2></a>
       <a href="open-research-problems"><h2>Research</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>

--- a/_sass/fund.scss
+++ b/_sass/fund.scss
@@ -14,7 +14,7 @@
   }
   h1 {
     text-align: center;
-    font-size: 72px;
+    font-size: 5rem;
     font-weight: 800;
     margin: 4px 0 16px 0;
   }

--- a/fund.html
+++ b/fund.html
@@ -6,7 +6,7 @@ layout: default-black
   <div class="fund">
     <div class="fund-heading">
       <span>GRIN GENERAL FUND</span>
-      <h1>3,641.22 GRIN</br>126.25 BTC</h1>
+      <h1>3.6k GRIN</br>126.25 BTC</h1>
       <small>Source: <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/reports/funding_transparency_2019Q4.md">2019 Q4 Transparency Report↗</a></small>
     </div>
     <p>

--- a/fund.html
+++ b/fund.html
@@ -6,38 +6,39 @@ layout: default-black
   <div class="fund">
     <div class="fund-heading">
       <span>GRIN GENERAL FUND</span>
-      <h1>$855,042</h1>
-      <small>70.77 BTC + 0 GRIN</small>
+      <h1>3,641.22 GRIN</br>126.25 BTC</h1>
+      <small>Source: <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/reports/funding_transparency_2019Q4.md">2019 Q4 Transparency Report↗</a></small>
     </div>
     <p>
-      The General Fund is for Grin’s ongoing projects and ever-expanding needs. Donations into this fund are always welcome and appreciated.
+      Grin is strictly non-profit. To keep Grin open and free from controlling influences, the project relies 100% on community donations for its funding needs. We ask any person, corporate entity or institution who sees potential in Grin/Mimblewimble technology to consider donating to the project. We hope that the vibrant cryptocurrency community will help Grin to achieve its goal of providing a reliable, scalable and privacy-driven blockchain implementation that truly belongs to everyone.
 
-      Donate to the General Fund to show up on the <a href="/friends">Friends of Grin</a> page.
+      Donate to the General Fund to be included on the <a href="/friends">Friends of Grin</a> page.
     </p>
-    <h3>Donate</h3>
-    <small class="fund-donation-type">GRIN DONATION ADDRESS</small>
-    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#grin" class="fund-address">Address in /grin-pm repo</a>.
+    <h3>Donate now</h3>
+    <small class="fund-donation-type">GRIN</small>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#grin" class="fund-address">Donation address in /grin-pm repo</a>
     <small class="fund-donation-type">BITCOIN LEGACY</small>
-    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#legacy" class="fund-address">Address in /grin-pm repo</a>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#legacy" class="fund-address">Donation address in /grin-pm repo</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>
-    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#segwit" class="fund-address">Address in /grin-pm repo</a>
-    <p>Note that the Bitcoin Segwit address is a Bech32 address. Please ensure your wallet supports sending to a Bech32 address before you use it. Many wallets and exchanges now support it, you can check adoption <a href="https://en.bitcoin.it/wiki/Bech32_adoption">here</a>.</p>
-    <small class="fund-donation-type">ETHEREUM</small>
-    <span class="fund-closed">Ethereum donations are suspended temporarily, and will be operational again as soon as possible.</span>
-    <small class="fund-donation-type">ZCASH</small>
-    <span class="fund-closed">Zcash donations are suspended temporarily, and will be operational again as soon as possible.</span>
-    <p>Funds donated in Ethereum and Zcash will be converted to Bitcoin shortly after for simplicity of accounting.</p>
+    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#segwit" class="fund-address">Donation address in /grin-pm repo</a>
+
+    <h3>Community funding principles</h3>
+    <p>Unlike the vast majority of blockchain projects, Grin's development is not motivated by profit for either its developers or early adopters. As a measure of this, the community has ensured that:
+    <ul>
+      <li>Grin's launch was pre-announced, open, and <a href="https://medium.com/@arjunblj/grin-and-the-mythical-fair-launch-395ca87a5e73">fair↗</a>. There were no pre-mining or any other funny business.</li>
+      <li>Grin will not engage in an ICO, STO, IEO, or any other type of similar offering.</li>
+      <li>Grin will not channel a mandatory percentage of mining rewards back to the developers (although it reserves the right to include a mechanism for doing so voluntarily)</li>
+      <li>Grin will not seek or accept any capital that comes with the expectation of future monetary return.</li>
+      <li>Grin will not seek or accept any capital that comes with the expectation of being able to unduly influence Grin's decision-making process.</li>
+    </ul>
 
     <h3>What is the General Fund?</h3>
-    <p>This is the general development fund intended to cover costs related to Grin’s ongoing development. While the team may not have visibility on every particular need that will arise, all donated funds will be used towards Grin’s development or promotion.
+    <p>This is the general development fund intended to cover costs related to Grin’s ongoing development. All donated funds will be used towards Grin’s development or promotion. This fund is managed entirely by the <a href="governance#core-team">Grin core team</a>, and all spending decisions are made public. The BTC funds are kept in a t-of-n multi-sig wallet, meaning no spending can occur without at least t core team members approving the transaction.</p>
 
-This fund is managed entirely by the Grin Technical Council, and all spending decisions will be made public. The funds are kept in a 3/5 Multisig wallet, meaning no spending can occur without at least 3 council members actively signing the transaction.
+    <h3>Friends of Grin</h3>
+    <p>Grin would not be where it is today where it not for the support received from the long list of individuals, companies, and fellow cryptocurrency projects. We celebrate those and the many others who opted to remain anonymous on our <a href="friends.html">Friends of Grin page</a>. Your contributions, big or small, will always be appreciated.</p>
 
-Some examples of where proceeds of this fund might be allocated (by no means exhaustive and subject to change):</p>
-
-    <h3>Further Information</h3>
-    <p>The Grin project is strictly non-profit. Please refer back to our Funding overview page for details on our fundraising appoach and our inclusive development philosophy.
-
-As always, anyone donating to this fund can optionally have themselves listed on the <a href="friends">Friends of Grin</a> page.</p>
+    <h3>Financials</h3>
+    <p>Information about donation wallet addresses, income and spending logs, and quarterly financial transparency reports are available in the <a href="https://github.com/mimblewimble/grin-pm#financials">/grin-pm repo↗</a>.</p>
   </div>
 </main>

--- a/index.html
+++ b/index.html
@@ -45,16 +45,19 @@ layout: default
             <p>“</p><a href="https://github.com/mimblewimble/grin/blob/master/doc/intro.md"><span>Introduction to MimbleWimble</span></a><p>” →</p>
           </li>
           <li class="section-3-link">
-            <p>“</p><a href="fund"><span>Grin General Fund</span></a><p>” →</p>
+            <p>“</p><a href="fund"><span>Funding</span></a><p>” →</p>
           </li>
           <li class="section-3-link">
             <p>“</p><a href="download.html#community"><span>Community Projects</span></a><p>” →</p>
+          </li>
+          <li class="section-3-link">
+            <p>“</p><a href="friends.html"><span>Friends of Grin</span></a><p>” →</p>
           </li>
         </ul>
         <div class="section-3-text">
           Grin is launched fairly — free of ICO,
           pre-mine or founder’s reward. We rely on donations to keep working on
-          the project. Support the movement by purchasing some <a href="https://tmgox.com/">merch</a> or making a
+          the project. Support the movement by purchasing some <a href="https://tmgox.com/">merch↗</a> or making a
           <a href="fund">donation</a>.</div>
       </div>
     </div>


### PR DESCRIPTION
### Introduction

In accordance with #172, this PR reworks the "General Fund" page into a new `Funding` section.
* Links to financials
* Updates general fund amount and links to a source
* Brings in the community funding principles from `funding.md`
* Removes Friends of Grin from the nav links
* Links to Friends of Grin from the funding page and also from index.

### Live preview
https://lehnberg.net/site/fund

### Screenshots
<img src="https://i.ibb.co/Mhcz36X/Screen-Shot-2020-01-06-at-14-16-19-fullpage.png" alt="desktop" width="600"/>
<img src="https://i.ibb.co/h8Nq6HT/Screen-Shot-2020-01-06-at-14-13-23.png" alt="mobile" width="200"/>