### PR TITLE
Fix: Various URL corrections

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
     </p>
     <div class="footer-links">
       <a href="https://forum.grin.mw">Forum</a>
-      <a href="https://gitter.im/grin_community/Lobby">Gitter</a>
+      <a href="https://keybase.io/team/grincoin">Keybase</a>
       <a href="https://grinnews.substack.com/">News</a>
       <a href="https://twitter.com/grinmw">Twitter</a>
       <a href="https://github.com/mimblewimble/grin">Github</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
       <a href="https://grin.mw">https://grin.mw</a>
     </p>
     <div class="footer-links">
-      <a href="https://www.grin-forum.org">Forum</a>
+      <a href="https://forum.grin.mw">Forum</a>
       <a href="https://gitter.im/grin_community/Lobby">Gitter</a>
       <a href="https://grinnews.substack.com/">News</a>
       <a href="https://twitter.com/grinmw">Twitter</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <div class="warning-footer">
-      <a href="https://www.grin-forum.org/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
+      <a href="https://forum.grin.mw/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
           block
           #524,160, Grin will hard fork. Click this banner for more information.</a>
     </div>
@@ -48,7 +48,7 @@
     {{ content }}
     {% include footer.html %}
     <div class="warning-footer">
-      <a href="https://www.grin-forum.org/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
+      <a href="https://forum.grin.mw/t/grin-v3-0-0-hard-fork-upgrade-jan-2020/" target="_blank">IMPORTANT UPDATE: On
           block
           #524,160, Grin will hard fork. Click this banner for more information.</a>
     </div>

--- a/assets/csv/entities.csv
+++ b/assets/csv/entities.csv
@@ -33,4 +33,4 @@ id,name,href,profile_src,description
 32,Anonymous,https://www.blockchain.com/btc/tx/491ee02543c25d729616de43685d837aa8461b453fd63da8eed88487db4176b7,assets/images/grin-logo.png,
 33,Gate.io,https://www.gate.io/,assets/images/logos/gateio_logo.png,We are one of the top 10 exchanges in the world
 34,Poloniex,https://poloniex.com,assets/images/logos/poloniex.png,
-35,Anonymous II,https://www.grin-forum.org/t/donation-to-the-grin-general-fund-nov-11/6446,assets/images/logos/blocks-not-bombs.png,use Blocks not Bombs
+35,Anonymous II,https://forum.grin.mw/t/donation-to-the-grin-general-fund-nov-11/6446,assets/images/logos/blocks-not-bombs.png,use Blocks not Bombs

--- a/community.md
+++ b/community.md
@@ -6,7 +6,7 @@ layout: page
 <br>
 
 ## Keybase Chat
-The main place for real time and asynch communication. End to end encrypted, works over TOR, and supports command line. [Grincoin team on keybase↗](https://https://keybase.io/team/grincoin)
+The main place for real time and asynch communication. End to end encrypted, works over TOR, and supports command line. [Grincoin team on keybase↗](https://keybase.io/team/grincoin)
 
 ### Bi-weekly meetings
 * every tuesday, at 15:00 [UTC](http://www.timebie.com/std/utc.php).

--- a/community.md
+++ b/community.md
@@ -26,7 +26,7 @@ The main place for real time and asynch communication. End to end encrypted, wor
 
 ## Grin Forum
 
-Longer form writing in the forum with the most comprehensive list of Grin & Mimblewimble related topics and thoughts: [https://www.grin-forum.org](https://www.grin-forum.org)
+Longer form writing in the forum with the most comprehensive list of Grin & Mimblewimble related topics and thoughts: [https://forum.grin.mw](https://forum.grin.mw)
 <br>
 
 ## Mailing List

--- a/open-research-problems.md
+++ b/open-research-problems.md
@@ -5,7 +5,7 @@ layout: page
 # Open Research Problems
 
 This document summarizes several open research problems related to Grin.
-Feel free to join us on [Gitter](https://gitter.im/grin_community/Dev) to discuss them. Funding available.
+Feel free to join us on [Keybase](https://keybase.io/team/grincoin) to discuss them. Funding available.
 
 ## Table of Contents
 

--- a/open-research-problems.md
+++ b/open-research-problems.md
@@ -156,7 +156,7 @@ https://arxiv.org/pdf/1905.10518.pdf
 https://github.com/mimblewimble/grin/issues/2857
 
 ### Forum thread
-https://www.grin-forum.org/t/erlay-bandwidth-efficient-transaction-relay-in-bitcoin/5081
+https://forum.grin.mw/t/erlay-bandwidth-efficient-transaction-relay-in-bitcoin/5081
 
 ## 9. Payment Channel Hubs
 

--- a/page-contribution-howto.md
+++ b/page-contribution-howto.md
@@ -38,7 +38,7 @@ or [deploy the website locally on your host](README.md#local-run) and visit http
 Adding a new file? Follow the guidelines [here](https://github.com/mmistakes/so-simple-theme#structure).
 
 ## Design changes
-Please come discuss design here in the [design chat](https://gitter.im/grin_community/design).
+Please come discuss design here in the [Keybase chat](https://keybase.io/team/grincoin).
 [It seems the logo is now finalized, at least for a while.](https://github.com/mimblewimble/site/issues/7)
 If your suggestion needs to be shown in context, create a separate page (like example-redesignX-YOUR_USERNAME.md and push to your github.io page, then share the link on the design chat etc.
 

--- a/sec_audit.md
+++ b/sec_audit.md
@@ -15,7 +15,7 @@ layout: page
 
 **The grin security audit funding campaign was completed on December 20th 2018. Thank you to all who generously donated!**
 
-**UPDATE 2019-10-23: The report and findings have now been published: https://www.grin-forum.org/t/grin-security-audit-2-results/6264**
+**UPDATE 2019-10-23: The report and findings have now been published: https://forum.grin.mw/t/grin-security-audit-2-results/6264**
 
 TL;DR Grin is nearing its final phases of development before the release of
 its cryptocurrency network (mainnet). To do so safely, the Grin codebase needs

--- a/yeastplume.md
+++ b/yeastplume.md
@@ -35,9 +35,9 @@ Raised (amounts as of Feb 3rd, 2019):
 
 I've been an active contributor to Grin since about May of 2017, and thanks to the generosity of the community Grin has been my full-time job since February of 2018. I hope my performance so far has been satisfactory to the community as well as beneficial to Grin and MimbleWimble development. I've left detailed information on my activities so far (as well as a few other random musings) in my Forum Progress update threads:
 
-- [Feb 2018 - April 2018](https://www.grin-forum.org/t/yeastplume-progress-update-thread-feb-april-2018/93)
-- [May 2018 - Sept 2018](https://www.grin-forum.org/t/yeastplume-progress-update-thread-may-sept-2018/361)
-- [Oct 2018 - Feb 2019](https://www.grin-forum.org/t/yeastplume-progress-update-thread-oct-18-feb-19/933)
+- [Feb 2018 - April 2018](https://forum.grin.mw/t/yeastplume-progress-update-thread-feb-april-2018/93)
+- [May 2018 - Sept 2018](https://forum.grin.mw/t/yeastplume-progress-update-thread-may-sept-2018/361)
+- [Oct 2018 - Feb 2019](https://forum.grin.mw/t/yeastplume-progress-update-thread-oct-18-feb-19/933)
 
 I invite you to have a look through there for precise information about what the previous funds have been used for, as well as information on my future development plans.
 


### PR DESCRIPTION
This PR:
1. Fixes a broken link to keybase as reported by @johndavies24
1. Replaces old grin-forum.org links with the new https://forum.grin.mw URL
1. Replaces links to gitter with the URL to the keybase team