### PR TITLE
Fix hash formatting for Windows users

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,13 +27,13 @@ layout: default
             v3.1.0</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          6c1a28fa709ebff0f142de41209991ed58a89170927cf698974d25ed72d920d7
+          6C1A28FA709EBFF0F142DE41209991ED58A89170927CF698974D25ED72D920D7
         </div>
         <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v3.1.0/grin-v3.1.0-win-x64.zip">grin
             v3.1.0</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          10e2968021e6487fc46e82006794f0eedfda292961a85f36e51276c176483739
+          10E2968021E6487FC46E82006794F0EEDFDA292961A85F36E51276C176483739
         </div>
       </div>
 


### PR DESCRIPTION
SHA256 hash outputs are in upper case on Windows machines. This PR changes the formatting of hashes for Windows releases to reflect what the user will see when verifying locally.