### PR TITLE
Create Blog section for announcements

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,6 +16,7 @@
     <li><a href="{{'governance' | relative_url}}">Governance</a></li>
     <li><a href="{{'fund' | relative_url}}">Funding</a></li>
     <li><a href="{{'open-research-problems' | relative_url}}">Research</a></li>
+    <li><a href="{{'blog' | relative_url}}">Blog</a></li>
     <li><a href="https://github.com/mimblewimble/grin">GitHub</a></li>
   </ul>
   <div id="hamburger" class="nav-hamburger">

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,6 @@
 <nav>
   <div class="nav-logo">
-    <a href="." id="grin-logo">
+    <a href="{{'.' | relative_url}}" id="grin-logo">
       <svg id="grin-logo-bare" width="61" height="61" viewBox="0 0 61 61" fill="none"
         xmlns="http://www.w3.org/2000/svg">
         <path
@@ -10,12 +10,12 @@
     </a>
   </div>
   <ul class="nav-list">
-    <li><a href="get-started">Get Started</a></li>
-    <li><a href="download">Download</a></li>
-    <li><a href="community">Community</a></li>
-    <li><a href="governance">Governance</a></li>
-    <li><a href="fund">Funding</a></li>
-    <li><a href="open-research-problems">Research</a></li>
+    <li><a href="{{'get-started' | relative_url}}">Get Started</a></li>
+    <li><a href="{{'download' | relative_url}}">Download</a></li>
+    <li><a href="{{'community' | relative_url}}">Community</a></li>
+    <li><a href="{{'governance' | relative_url}}">Governance</a></li>
+    <li><a href="{{'fund' | relative_url}}">Funding</a></li>
+    <li><a href="{{'open-research-problems' | relative_url}}">Research</a></li>
     <li><a href="https://github.com/mimblewimble/grin">GitHub</a></li>
   </ul>
   <div id="hamburger" class="nav-hamburger">

--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -14,13 +14,13 @@
   </head>
   <body class="black">
     <div id="fullscreen-menu" class="nav-hamburger-fullscreen">
-      <a href="."><h2>Index</h2></a>
-      <a href="get-started"><h2>Get Started</h2></a>
-      <a href="download"><h2>Download</h2></a>
-      <a href="community"><h2>Community</h2></a>
-      <a href="governance"><h2>Governance</h2></a>
-      <a href="fund"><h2>Funding</h2></a>
-      <a href="open-research-problems"><h2>Research</h2></a>
+      <a href="{{'.' | relative_url}}"><h2>Index</h2></a>
+      <a href="{{'get-started' | relative_url}}"><h2>Get Started</h2></a>
+      <a href="{{'download' | relative_url}}"><h2>Download</h2></a>
+      <a href="{{'community' | relative_url}}"><h2>Community</h2></a>
+      <a href="{{'governance' | relative_url}}"><h2>Governance</h2></a>
+      <a href="{{'fund' | relative_url}}"><h2>Funding</h2></a>
+      <a href="{{'open-research-problems' | relative_url}}"><h2>Research</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>
     <div class="full-header">

--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -21,6 +21,7 @@
       <a href="{{'governance' | relative_url}}"><h2>Governance</h2></a>
       <a href="{{'fund' | relative_url}}"><h2>Funding</h2></a>
       <a href="{{'open-research-problems' | relative_url}}"><h2>Research</h2></a>
+      <a href="{{'blog' | relative_url}}"><h2>Blog</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>
     <div class="full-header">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
       <a href="{{'governance' | relative_url}}"><h2>Governance</h2></a>
       <a href="{{'fund' | relative_url}}"><h2>Funding</h2></a>
       <a href="{{'open-research-problems' | relative_url}}"><h2>Research</h2></a>
+      <a href="{{'blog' | relative_url}}"><h2>Blog</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>
     <div class="full-header">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,13 +18,13 @@
           block #786,240, Grin will hard fork. Click this banner for more information.</a>
     </div>
     <div id="fullscreen-menu" class="nav-hamburger-fullscreen">
-      <a href="."><h2>Index</h2></a>
-      <a href="get-started"><h2>Get Started</h2></a>
-      <a href="download"><h2>Download</h2></a>
-      <a href="community"><h2>Community</h2></a>
-      <a href="governance"><h2>Governance</h2></a>
-      <a href="fund"><h2>Funding</h2></a>
-      <a href="open-research-problems"><h2>Research</h2></a>
+      <a href="{{'.' | relative_url}}"><h2>Index</h2></a>
+      <a href="{{'get-started' | relative_url}}"><h2>Get Started</h2></a>
+      <a href="{{'download' | relative_url}}"><h2>Download</h2></a>
+      <a href="{{'community' | relative_url}}"><h2>Community</h2></a>
+      <a href="{{'governance' | relative_url}}"><h2>Governance</h2></a>
+      <a href="{{'fund' | relative_url}}"><h2>Funding</h2></a>
+      <a href="{{'open-research-problems' | relative_url}}"><h2>Research</h2></a>
       <a href="https://github.com/mimblewimble/grin"><h2>GitHub</h2></a>
     </div>
     <div class="full-header">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+
+<main class="page white">
+
+<H1>{{ page.title }}</H1>
+<p>{{ page.date | date: "%b %-d %Y" }} ∙ {{ page.author }}</p>
+
+{{ content }}
+
+</main>

--- a/_posts/2020-07-02-grin-4-released.md
+++ b/_posts/2020-07-02-grin-4-released.md
@@ -38,7 +38,7 @@ Full release notes for both the Node and wallet are linked below:
 
 **Further Details**
 
-https://github.com/mimblewimble/grin/issues/3341
+[mimblewimble/grin#3341](https://github.com/mimblewimble/grin/issues/3341)
 
 **Wallet**
 
@@ -47,4 +47,4 @@ https://github.com/mimblewimble/grin/issues/3341
 
 **Futher Details**
 
-https://github.com/mimblewimble/grin-wallet/issues/456
+[mimblewimble/grin-wallet#456](https://github.com/mimblewimble/grin-wallet/issues/456)

--- a/_posts/2020-07-02-grin-4-released.md
+++ b/_posts/2020-07-02-grin-4-released.md
@@ -1,0 +1,50 @@
+---
+layout: post
+title:  "Grin & Grin Wallet 4.0.0 Released"
+author: "@yeastplume"
+categories: blog
+---
+
+_This post was originally published [in the forums](https://forum.grin.mw/t/grin-grin-wallet-4-0-0-released/7504)._
+
+Grin and Grin wallet 4.0.0 have been released and is ready for general use in advance of Grin's 3rd Hardfork scheduled to occur on block 786240.
+
+A particularly large feature of the 4.0.0 is the implementation of the new [Slatepack standard](https://github.com/mimblewimble/grin-rfcs/blob/master/text/0015-slatepack.md) for sending transactions between parties. This standard builds on top of previous work that enabled TOR transactions, and should serve as a foundation for addressing Grin's long-term usability challenges. Though there may be some pain transitioning to the new work flow I think the long-term results will be worth it.
+
+On the node side, there are many fixes and under-the-hood improvements, as well as initial work to support  ["No Recent Duplicate" Kernels](https://github.com/mimblewimble/grin-rfcs/blob/master/text/0013-nrd-kernels.md), a unique approach to relative timelocks (vital for future payment channel support). This is a very new construction so 4.0.0 will allow NRD kernels on floonet to enable testing and further development.
+
+Once again, thanks to everyone on the development team and the community for all of their hard work and continuing energy.  This release and enhancements therein are the culmination of thousands of collective hours of thought, discussion, arguing, development, testing, promoting and graft by (I think we can safely say) hundreds of people across many disciplines. The road ahead for Grin remains challenging and uncertain, but I don't think we could be in a better position to travel it.
+
+Full release notes for both the Node and wallet are linked below:
+
+**Binaries**
+
+[Grin 4.0.0 Binaries](https://github.com/mimblewimble/grin/releases/tag/v4.0.0)
+[Grin Wallet 4.0.0 Binaries](https://github.com/mimblewimble/grin-wallet/releases/tag/v4.0.0)
+
+**Release Planning**
+
+[Planning notes for the 4.0.0 release](https://github.com/mimblewimble/grin-pm/issues/248)
+
+**Major changes and enhancements**
+
+**Node**:
+
+* New Cuckarooz PoW and header version 4 for latest hardfork.
+* TUI optimizations and overall code improvements
+* Server and backend DB code optimizations and improvements
+* BlockHeader via API now includes all relevant fields (including MMR size)
+* Feature flagged NRD kernel support (enabled in floonet, remains disabled in mainnet)
+
+**Further Details**
+
+https://github.com/mimblewimble/grin/issues/3341
+
+**Wallet**
+
+* Slate version V4, a much more compact version of the slate.
+* Full implementation of the [Slatepack standard](https://github.com/j01tz/grin-rfcs/blob/slatepack/text/0000-slatepack.md) 
+
+**Futher Details**
+
+https://github.com/mimblewimble/grin-wallet/issues/456

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+---
+
+# Blog
+
+The [core team]({{ 'governance.html#core-team' | relative_url }}) uses this blog to communicate big announcements in Grin.
+
+## List of posts
+{% for post in site.posts %}
+* {{ post.date | date: "%b %-d %Y" }}: [{{ post.title }}]({{ post.url }})
+{% endfor %}


### PR DESCRIPTION
This PR adds a new blog section on the website, `grin.mw/blog`, for important core team announcements, such as:
* new releases
* security vulnerabilities
* governance decisions

Previously, this has been handled in forum posts, and while the practice of creating forum posts where community members can discuss announcements should continue, it also makes sense to keep all announcements in one place visible to the public, and clearly version tracked.

## PR overview
* Improve menu navigation with relative links that do not break if accessed from within the `/blog` hierarchy
* Add "Blog" menu navigation item, that links to a default "Blog page" with a simple list of blog posts
* Add example blog post, a verbatim copy of Yeastplume's recent 4.0.0 announcement on the forum.

## Live examples
* https://lehnberg.net/site/blog/
* https://lehnberg.net/site/blog/2020/07/02/grin-4-released

_Note that the URL in /site/blog/ is broken due to it being hosted under my personal GitHub fork rather than on production._

## Details

Most of the heavy lifting is handled by Jekyll, and publishing a new blog post is as easy as creating a new markdown file under the `_posts` directory with the following front-matter included:

```
---
layout: post
title:  "Grin & Grin Wallet 4.0.0 Released"
author: "@yeastplume"
categories: blog
---
```

**Important:**
* Include `categories: blog` in order for Jekyll to put the posts in the correct site hierarchy.
* Name the file `YYYY-MM-DD-post-title.md` and the URL for the post then becomes `https://grin.mw/blog/YYYY/MM/DD/post-title`.