### PR TITLE
Announce Grin v4.0.1 release

### DIFF
--- a/_posts/2020-07-13-grin-node-401-released.md
+++ b/_posts/2020-07-13-grin-node-401-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Grin node patched to v4.0.1"
+author: "@lehnberg"
+categories: blog
+---
+
+Grin node v4.0.1 has been released and is ready for use in advance of this week's scheduled hard fork, occurring at block height #786,240. Binaries are as usual available from the [download section]({{'download' | relative_url}}).
+
+This release includes a patch for a bug that was causing a thread panic. Details in the issue [mimblewimble/grin/#3386](https://github.com/mimblewimble/grin/issues/3386) and the accompanying pull request [mimblewimble/grin/#3387](https://github.com/mimblewimble/grin/pull/3387).
+
+The version 4.x family of releases include many improvements and fixes, and is required in order to interact with the network after the scheduled hard fork, currently estimated to occur on Sunday Jul 19. All users are encouraged to upgrade.
+
+For more details, see the [previous post announcing version 4.0.0]({% post_url 2020-07-02-grin-4-released %}).

--- a/download.html
+++ b/download.html
@@ -29,11 +29,11 @@ layout: default
         <div class="codebox">
           25108E0BF17766E3D4B83BCFF66371F712FF850F6E0E7F563E8F070575AFE8CA
         </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v4.0.0/grin-v4.0.0-win-x64.zip">grin
-            v4.0.0</a></h3>
+        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v4.0.1/grin-v4.0.1-win-x64.zip">grin
+            v4.0.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          960371BB7B4A6C5A47E284B1B4546EFDD027623E362838CCAF85B2931023ABBB
+          3EE60A2180E4FBCC638166CDCC2415F9BA17F2BE0E6312ACE8148FA722FAFEF7
         </div>
       </div>
 
@@ -49,11 +49,11 @@ layout: default
         <div class="codebox">
           brew install grin-wallet
         </div>
-        <h3><a href="https://github.com/mimblewimble/grin/releases/download/v4.0.0/grin-v4.0.0-macos.tar.gz">grin
-            v4.0.0</a></h3>
+        <h3><a href="https://github.com/mimblewimble/grin/releases/download/v4.0.1/grin-v4.0.1-macos.tar.gz">grin
+            v4.0.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          dad23536f02a983ab0feb7d7c66e51026a043db193f9d580e842d6ac39a1645f
+          185b0a9cd32ff119d1e14c2efffa3cf7a9dac8b48fbe864e2f40fa7b93834ce3
         </div>
         <div class="codebox-heading">or with homebrew</div>
         <div class="codebox">
@@ -69,11 +69,11 @@ layout: default
         <div class="codebox">
           5a8762a7307243d8767962d23407bd74e38127ef9bd97c1c4a79b38655a23b7f
         </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v4.0.0/grin-v4.0.0-linux-amd64.tar.gz">grin
-            v4.0.0</a></h3>
+        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v4.0.1/grin-v4.0.1-linux-amd64.tar.gz">grin
+            v4.0.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          6141123daf33370ca84245aee6346a839f2bb2c05f0e271f9e4ad563aa81b769
+          1bbc0ae41b3fbf21aad1a58b655385f9ebacc7ef99f83a4f6d078f149e7d67f5
         </div>
 	<div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
         <div class="codebox">

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
       <div>
         <span class="section-1-grin">GRiN</span>
         <span class="section-1-v">v</span>
-        <span class="section-1-version">4.0.0</span>
+        <span class="section-1-version">4.0.1</span>
       </div>
       <p class="section-1-text">Electronic transactions for all.
         Without censorship or restrictions.


### PR DESCRIPTION
* Bumps version number on the website
* Adds blog post announcement
* Adds SHA256 hashes and download links:

```bash
$ shasum -a 256 grin-v4.0.1-linux-amd64.tar.gz
          shasum -a 256 grin-v4.0.1-macos.tar.gz
          shasum -a 256 grin-v4.0.1-win-x64.zip
1bbc0ae41b3fbf21aad1a58b655385f9ebacc7ef99f83a4f6d078f149e7d67f5  grin-v4.0.1-linux-amd64.tar.gz
185b0a9cd32ff119d1e14c2efffa3cf7a9dac8b48fbe864e2f40fa7b93834ce3  grin-v4.0.1-macos.tar.gz
3ee60a2180e4fbcc638166cdcc2415f9ba17f2be0e6312ace8148fa722fafef7  grin-v4.0.1-win-x64.zip
```
