### PR TITLE
FIX issue #201: The image cover the headline on mobile

### DIFF
--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -141,7 +141,7 @@
   .section-1-lights {
     max-width: 100%;
     padding: 0 16px;
-	margin-bottom: -15%;
+    margin-bottom: -15%;
   }
   .section-2 {
     padding: 24px 16px 16px 16px;

--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -141,6 +141,7 @@
   .section-1-lights {
     max-width: 100%;
     padding: 0 16px;
+	margin-bottom: -15%;
   }
   .section-2 {
     padding: 24px 16px 16px 16px;


### PR DESCRIPTION
The image of "section 1" cover the headline of "section 2" on mobile. (#201 )

## Before:
![image](https://user-images.githubusercontent.com/8020386/87366927-71a66b00-c5ac-11ea-9415-3651e35abed6.png)

## After:
![image](https://user-images.githubusercontent.com/8020386/87366929-75d28880-c5ac-11ea-95ac-4c47e351f7f9.png)

