### PR TITLE
FIX Design issues on 'Get Started' page

### DIFF
--- a/_sass/get-started.scss
+++ b/_sass/get-started.scss
@@ -99,6 +99,7 @@
     position: absolute;
     bottom: -70px;
     right: 0;
+    z-index: 10;
 }
 .right-column{
     margin-left: auto;
@@ -108,6 +109,7 @@
     position: absolute;
     bottom: -70px;
     left: 0;
+    z-index: 10;
 }
 .start-content div div a,
 .start-content div div a:link{

--- a/_sass/get-started.scss
+++ b/_sass/get-started.scss
@@ -96,14 +96,20 @@
     text-align: right;
 }
 .left-column div{
-    margin-top: 25px;
+    position: absolute;
+    bottom: -70px;
+    right: 0;
+    z-index: 10;
 }
 .right-column{
     margin-left: auto;
     text-align: left;
 }
 .right-column div{
-    margin-top: 25px;
+    position: absolute;
+    bottom: -70px;
+    left: 0;
+    z-index: 10;
 }
 .start-content div div a,
 .start-content div div a:link{

--- a/_sass/get-started.scss
+++ b/_sass/get-started.scss
@@ -96,20 +96,14 @@
     text-align: right;
 }
 .left-column div{
-    position: absolute;
-    bottom: -70px;
-    right: 0;
-    z-index: 10;
+    margin-top: 25px;
 }
 .right-column{
     margin-left: auto;
     text-align: left;
 }
 .right-column div{
-    position: absolute;
-    bottom: -70px;
-    left: 0;
-    z-index: 10;
+    margin-top: 25px;
 }
 .start-content div div a,
 .start-content div div a:link{

--- a/_sass/get-started.scss
+++ b/_sass/get-started.scss
@@ -49,7 +49,6 @@
     height: 50px;
     -webkit-transform: translate(-50%, -9px);
             transform: translate(-50%, -9px);
-    z-index: 10;
 }
 .start-block:nth-child(1)::after{
     background: url(../images/getting-started/number-1.svg?1528322191) no-repeat;
@@ -100,7 +99,6 @@
     position: absolute;
     bottom: -70px;
     right: 0;
-    z-index: 10;
 }
 .right-column{
     margin-left: auto;
@@ -110,7 +108,6 @@
     position: absolute;
     bottom: -70px;
     left: 0;
-    z-index: 10;
 }
 .start-content div div a,
 .start-content div div a:link{

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -144,5 +144,6 @@ nav {
   }
   .nav-hamburger-fullscreen {
     display: flex;
+    z-index: 30;
   }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -163,4 +163,5 @@ li {
   background-color: #e74c3c;
   color: white;
   text-align: center;
+  z-index: 20;
 }


### PR DESCRIPTION
Design issues on 'Get Started' page - fix #213

1. The steps numbers cover the nav menu on mobile.
2. The steps numbers cover the 'IMPORTANT UPDATE' on mobile.
3. The steps buttons cover the 'IMPORTANT UPDATE' on desktop.

URL: https://grin.mw/get-started

## 1. The steps numbers cover the nav menu on mobile.
![menu-m](https://user-images.githubusercontent.com/8020386/88270361-1ab93800-cd08-11ea-981f-efb058e89a98.gif)

## 2. The steps numbers cover the 'IMPORTANT UPDATE' on mobile.
![footer-m](https://user-images.githubusercontent.com/8020386/88270535-610e9700-cd08-11ea-947e-11fc30c66c63.gif)

## 3. The steps buttons cover the 'IMPORTANT UPDATE' on desktop.
![footer-d](https://user-images.githubusercontent.com/8020386/88270562-679d0e80-cd08-11ea-92f1-c5e35bec4337.gif)