### PR TITLE
remove twitter from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,6 @@
       <a href="https://forum.grin.mw">Forum</a>
       <a href="https://keybase.io/team/grincoin">Keybase</a>
       <a href="https://grinnews.substack.com/">News</a>
-      <a href="https://twitter.com/grinmw">Twitter</a>
       <a href="https://github.com/mimblewimble/grin">Github</a>
     </div>
   </div>


### PR DESCRIPTION
twitter.com/grinmw is suspended and the owner can't be reached.
Remove it for now.