### PR TITLE
Design improvement for 'Download' page

### DIFF
--- a/_sass/download.scss
+++ b/_sass/download.scss
@@ -1,7 +1,6 @@
 .download-heading {
   text-align: center;
-  padding :20px;
-  border-bottom: 1px solid #dadada;
+  padding: 40px 20px 30px 20px;
   background-color: white;
   p {
     max-width: 600px;
@@ -35,6 +34,7 @@
 .site.pad.community-pad {
   padding-top: 40px;
   padding-bottom: 40px;
+  border-top: 1px solid #dadada;
 }
 
 .community {
@@ -54,7 +54,7 @@
   text-align: center;
 }
 .community-content {
-  margin-top: 24px;
+  margin-top: 40px;
   background-color: white;
 }
 .community-row {
@@ -66,6 +66,7 @@
   height: 80px;
   width: 80px;
   margin-right: 16px;
+  border-radius: 15px;
 }
 .community-row-content {
   margin-top: 4px;
@@ -123,10 +124,9 @@
 /* Style the tab content */
 .tabcontent {
   display: none;
-  padding: 6px 12px;
-  padding-bottom: 10px;
+  padding: 20px;
   border: 1px solid #ccc;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   a {
     margin-bottom:10px;
   }


### PR DESCRIPTION
**Some minor changes:**

- Changed page headline padding (same 'Get Started' page).
- Remove 'Download' headline border bottom.
- Change tabs padding.
- Add border top to the 'Community Projects' section.
- Change 'Community Projects' headline padding.
- Add border radius to 'Ironbelly' (like the official logo)

![gif](https://user-images.githubusercontent.com/8020386/88610343-f8813a80-d0b8-11ea-8633-eb7243ba6e95.gif)


## Before:
![image](https://user-images.githubusercontent.com/8020386/88609911-da670a80-d0b7-11ea-974c-11e91b501fba.png)

## After:
![image](https://user-images.githubusercontent.com/8020386/88609967-f9fe3300-d0b7-11ea-853a-f8167d51c8ff.png)
