### PR TITLE
Add an updated Code of Conduct

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,6 @@
         <a href="https://grinnews.substack.com/">News</a>
         <a href="https://github.com/mimblewimble/grin">Github</a>
         <br>
-        <strong>Policies</strong>
         <a href="{{ 'policies/code_of_conduct' | relative_url }}">Code of Conduct</a>
         <a href="https://github.com/mimblewimble/grin-security">Security, canaries, keys</a>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,15 +7,18 @@
       Tom Elvis Jedusor @ 19 July, 2016.
       Andrew Poelstra @ e9f45ec.
 
-      <a href="https://github.com/mimblewimble/grin-security">Security policy, canaries, and keys</a>.
-
       <a href="https://grin.mw">https://grin.mw</a>
+
     </p>
     <div class="footer-links">
-      <a href="https://forum.grin.mw">Forum</a>
-      <a href="https://keybase.io/team/grincoin">Keybase</a>
-      <a href="https://grinnews.substack.com/">News</a>
-      <a href="https://github.com/mimblewimble/grin">Github</a>
+        <a href="https://forum.grin.mw">Forum</a>
+        <a href="https://keybase.io/team/grincoin">Keybase</a>
+        <a href="https://grinnews.substack.com/">News</a>
+        <a href="https://github.com/mimblewimble/grin">Github</a>
+        <br>
+        <strong>Policies</strong>
+        <a href="{{ 'policies/code_of_conduct' | relative_url }}">Code of Conduct</a>
+        <a href="https://github.com/mimblewimble/grin-security">Security, canaries, keys</a>
     </div>
   </div>
 </footer>

--- a/community.md
+++ b/community.md
@@ -35,3 +35,15 @@ Longer form writing in the forum with the most comprehensive list of Grin & Mimb
 ## Mailing List
 
 Focused on development, the [Mimblewimble mailing list↗](https://lists.launchpad.net/mimblewimble/) offers insight into the evolution of the protocol and some of the motivations behind the project's design decisions.
+
+## Community standards
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+<div>
+   <a class="btn btn-bright" href="{{ 'policies/code_of_conduct' | relative_url }}">Read the code of conduct</a>
+   <a class="btn btn-bright" href="mailto:grinmods@googlegroups.com">Make a complaint</a>
+</div>

--- a/policies/code_of_conduct.md
+++ b/policies/code_of_conduct.md
@@ -1,0 +1,84 @@
+---
+layout: page
+---
+
+# Code of Conduct
+
+Contact: [grinmods@googlegroups.com](mailto:grinmods@googlegroups.com)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by email at [grinmods@googlegroups.com](mailto:grinmods@googlegroups.com). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).


### PR DESCRIPTION
As per https://github.com/mimblewimble/grin-pm/issues/309

## This PR:
1. Updates the code of conduct (CoC) to follow [contributor covenant v2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html) with no significant changes in wording. (Previously the CoC was based on the one used by Rust Language, which in turn is based off contributor covenant v1.3.)
2. Adds the CoC to the website at `https://grin.mw/policies/code_of_conduct`.
3. Adds a link to the CoC in the footer, and groups it together with the link to `/grin-security`
4. Adds a reference to the CoC and call to actions at the bottom of `https://grin.mw/community`

## If merged:
* Each repo in the `/mimblewimble` Github org will have its `CODE_OF_CONDUCT.md` updated to point to `https://grin.mw/policies/code_of_conduct`.
* Keybase stickies and forum.grin.mw will be similarly updated.

## Previews

### Live website
https://lehnberg.net/site/policies/code_of_conduct

### Screenshots

#### Code of conduct
<a href="https://ibb.co/y6ktstn"><img src="https://i.ibb.co/48SzNzZ/Screenshot-2020-08-13-at-13-05-22.png" alt="Screenshot-2020-08-13-at-13-05-22" border="0"></a>

#### grin.mw/community
<a href="https://ibb.co/25NsHhy"><img src="https://i.ibb.co/yVSY7PX/Screenshot-2020-08-13-at-13-07-06.png" alt="Screenshot-2020-08-13-at-13-07-06" border="0"></a>

#### Page footer
<a href="https://ibb.co/0c98SxF"><img src="https://i.ibb.co/2yMmQTs/Screenshot-2020-08-13-at-13-08-17.png" alt="Screenshot-2020-08-13-at-13-08-17" border="0"></a>