### PR TITLE
[DNM] Change Get Started

### DIFF
--- a/community.md
+++ b/community.md
@@ -24,7 +24,7 @@ The main place for real time and asynch communication. End to end encrypted, wor
 1. Install and setup keybase.
 2. Join the grin community:
    * **From the app:** Select "Teams" >> "Join a team" and then type "grincoin"
-   * **From the command line:** `keybase team request-access grincoin`   
+   * **From the command line:** `keybase team request-access grincoin`
 <br>
 
 ## Grin Forum
@@ -35,3 +35,8 @@ Longer form writing in the forum with the most comprehensive list of Grin & Mimb
 ## Mailing List
 
 Focused on development, the [Mimblewimble mailing list↗](https://lists.launchpad.net/mimblewimble/) offers insight into the evolution of the protocol and some of the motivations behind the project's design decisions.
+<br>
+
+## Channels
+
+[Discord↗](https://discord.com/invite/wH6uj7z) and [Telegram↗](https://telegram.me/GrinCoin) channels maintained by independant community members.

--- a/download.html
+++ b/download.html
@@ -9,6 +9,8 @@ layout: default
       <div class="download-subheading">
         Please note that grin and grin-wallet come without a graphical user interface (GUI).<br>
         For GUI wallet and node see the community projects below.
+        </br></br>
+        <a href="docs.grin.mw/docs/getting-started/quickstart/install/">Quickstart↗</a>
       </div>
     </div>
     <section class="download-section">
@@ -87,7 +89,6 @@ layout: default
   <a name="community"><div class="community"></a>
     <h2>Community Projects</h2>
     <div class="community-subheading">
-      Grin does not endorse nor support any of the listed projects.<br>
       We only list community projects, use at your own risk.
     </div>
     <div class="community-content">

--- a/get-started.html
+++ b/get-started.html
@@ -13,10 +13,10 @@ layout: default
           <div class="left-column">
             <h2 id="inform">
               Inform yourself</h2>
-            <p>Grin is different than what you know and use every day. Before you start using Grin, there are a few things that you need to know in order to use it securely and avoid common pitfalls. Start with the basics. What is Grin? How is it used? How is it different than Bitcoin?
+            <p>Grin might be different than what you know, so start with the basics. What is Grin? How is it used? What makes it interesting?
               </p>
             <div>
-              <a class="btn-bright" href="https://github.com/mimblewimble/grin/blob/master/doc/grin4bitcoiners.md">Read more</a>
+              <a class="btn-bright" href="https://docs.grin.mw">Read more</a>
             </div>
           </div>
         </div>
@@ -26,8 +26,8 @@ layout: default
         <div class="start-content">
           <div class="right-column">
             <h2 id="choose">
-              Run your Node / Choose your wallet</h2>
-            <p>Grin makes it easy and fast to setup a full node. There is also a wide range of grin wallets available for all major operating systems and devices to serve a variety of your needs. Choosing a wallet is easy and can be done in minutes.</p>
+              Run Grin</h2>
+            <p>Setting up your own node and wallet is easy and can be done in minutes. Be sure to satisfy the full node gods.</p>
             <div>
               <a class="btn-bright" href="/download">Download</a>
             </div>
@@ -40,9 +40,9 @@ layout: default
           <div class="left-column">
             <h2 id="get">
               Get Grin</h2>
-            <p>You can get Grin by accepting it as a payment for goods and services. You can also buy Grin on different exchanges.</p>
+            <p>You can get Grin by mining, buying on an exchange or accepting it as a payment. Remember, not your keys, not your coins.</p>
             <div>
-              <a class="btn-bright" href="https://github.com/mimblewimble/docs/wiki/Community-projects#exchanges">Buy Grin</a>
+              <a class="btn-bright" href="docs.grin.mw/wiki/exchanges">Buy</a>
             </div>
           </div>
         </div>
@@ -52,10 +52,10 @@ layout: default
         <div class="start-content">
           <div class="right-column">
             <h2 id="spend">
-              Spend Grin</h2>
-            <p>There are a growing number of services and merchants accepting Grin all over the world. Use Grin to pay them and rate your experience to help them gain more visibility.</p>
+              Join the conversation</h2>
+            <p>Grin is driven entirely by individual users and contributors, and you are most welcome to join the dicussions or contribute yourself.</p>
             <div>
-              <a class="btn-bright" href="https://tmgox.com">Buy Grin Swag</a>
+              <a class="btn-bright" href="/community">Community</a>
             </div>
           </div>
         </div>

--- a/get-started.html
+++ b/get-started.html
@@ -27,7 +27,7 @@ layout: default
           <div class="right-column">
             <h2 id="choose">
               Run Grin</h2>
-            <p>Setting up your own node and wallet is easy and can be done in minutes. Be sure to satisfy the full node gods.</p>
+            <p>Setting up your own node and wallet is easy and can be done in minutes.</p>
             <div>
               <a class="btn-bright" href="/download">Download</a>
             </div>
@@ -40,9 +40,9 @@ layout: default
           <div class="left-column">
             <h2 id="get">
               Get Grin</h2>
-            <p>You can get Grin by mining, buying on an exchange or accepting it as a payment. Remember, not your keys, not your coins.</p>
+            <p>You can get Grin by mining, buying on an exchange, or accepting it as payment. But remember, not your keys not your coins.</p>
             <div>
-              <a class="btn-bright" href="docs.grin.mw/wiki/exchanges">Buy</a>
+              <a class="btn-bright" href="docs.grin.mw/docs/wiki/exchanges">Get Grin</a>
             </div>
           </div>
         </div>
@@ -53,7 +53,7 @@ layout: default
           <div class="right-column">
             <h2 id="spend">
               Join the conversation</h2>
-            <p>Grin is driven entirely by individual users and contributors, and you are most welcome to join the dicussions or contribute yourself.</p>
+            <p>Grin is driven entirely by individual users and contributors, and you are most welcome to join the discussions or to contribute yourself.</p>
             <div>
               <a class="btn-bright" href="/community">Community</a>
             </div>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: default
       <div>
         <ul>
           <li class="section-3-link">
-            <p>“</p><a href="https://github.com/mimblewimble/grin/blob/master/doc/intro.md"><span>Introduction to MimbleWimble</span></a><p>” →</p>
+            <p>“</p><a href="docs.grin.mw/wiki/introduction/ecc"><span>Introduction to MimbleWimble</span></a><p>” →</p>
           </li>
           <li class="section-3-link">
             <p>“</p><a href="fund"><span>Funding</span></a><p>” →</p>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: default
       <div>
         <ul>
           <li class="section-3-link">
-            <p>“</p><a href="docs.grin.mw/wiki/introduction/ecc"><span>Introduction to MimbleWimble</span></a><p>” →</p>
+            <p>“</p><a href="docs.grin.mw/docs/wiki/introduction/ecc"><span>Introduction to MimbleWimble</span></a><p>” →</p>
           </li>
           <li class="section-3-link">
             <p>“</p><a href="fund"><span>Funding</span></a><p>” →</p>


### PR DESCRIPTION
- Modify the text and resources in the Get Started Page to be more relevant.
- Add [Quickstart](https://paouky.github.io/docs/getting-started/quickstart/install/) guide link to Download page.
- Remove line "Grin does not support nor endorse any of the listed projects" from Download page. (Grin itself can't endorse nor support anything).
- Change home page link to the Mimblewimble introduction in the new docs.
- Add discord and telegram links in the Community page (They are nearly impossible to find but are often important to new users).

*Requires moving the new docs to docs.grin.mw before merging.*
