### PR TITLE
Fix 'quickstart' docs link

### DIFF
--- a/download.html
+++ b/download.html
@@ -12,7 +12,7 @@ layout: default
       </div>
     </div>
     <div class="download-quickstart">
-      <a href="docs.grin.mw/docs/getting-started/quickstart/install/">Quickstart↗</a>
+      <a href="https://docs.grin.mw/getting-started/quickstart/install/">Quickstart↗</a>
     </div>
     <section class="download-section">
       <!-- Tab links -->


### PR DESCRIPTION
Fix quickstart docs link, missing 'https://' https://github.com/mimblewimble/site/pull/233/commits/c7e5578ea40dd97f189e43e47eae62a42e6f332d