### PR TITLE
Add hashrate notice banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,9 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/main.css" />
   </head>
   <body>
+    <div class="warning-footer">
+      IMPORTANT NOTICE: The Grin network hashrate has increased considerably over a short period of time. Notably this coincides with the nicehash rate doubling in this time with well over 50% of the network hashrate currently outside of known pools. Considering these circumstances it is wise to wait for extra confirmations on transactions for payment finality.
+    </div>
     <div id="fullscreen-menu" class="nav-hamburger-fullscreen">
       <a href="{{'.' | relative_url}}"><h2>Index</h2></a>
       <a href="{{'get-started' | relative_url}}"><h2>Get Started</h2></a>
@@ -47,6 +50,9 @@
     </header>
     {{ content }}
     {% include footer.html %}
+    <div class="warning-footer">
+      IMPORTANT NOTICE: The Grin network hashrate has increased considerably over a short period of time. Notably this coincides with the nicehash rate doubling in this time with well over 50% of the network hashrate currently outside of known pools. Considering these circumstances it is wise to wait for extra confirmations on transactions for payment finality.
+    </div>
     <script type="text/javascript">
       var logo = document.getElementById('grin-logo-bare');
       var fullLogo = document.getElementById('grin-logo-full-svg');

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -141,3 +141,26 @@ li {
 
 @media (max-width: 768px) {
 }
+
+.warning-footer a {
+  border-bottom: 1px solid #e74c3c;
+  color: white;
+  margin-left: 10px;
+  margin-right:10px;
+}
+
+.warning-footer {
+  position: fixed;
+  justify-content: center;
+  box-shadow: 0 10px 45px -12px rgba(93, 90, 50, 0.25), 0 18px 36px -18px rgba(0, 0, 0, .3);
+  left: 0;
+  align-items: center;
+  display: flex;
+  bottom: 0;
+  width: 100%;
+  height: 50px;
+  background-color: #e74c3c;
+  color: white;
+  text-align: center;
+  z-index: 20;
+}


### PR DESCRIPTION
Adds a banner with a notice about hashrate concerns + encouragement to wait for more confirmations before accepting payments.

- Hashrate has increased significantly on the Grin network recently
- Nicehash appears to have a pool with a larger hashrate than Grin network
- Price on Nicehash has doubled recently
- Significantly more than 50% of current Grin network hashrate is unknown

All of these factors should lead to caution when accepting large payments with low confirmations until the network hashrate dynamics stabilize.