### PR TITLE
Remove Ironbelly wallet

### DIFF
--- a/download.html
+++ b/download.html
@@ -113,16 +113,6 @@ layout: default
           <div class="community-row-category">Windows, Linux, macOS, and Android</div>
         </div>
       </div>
-      <div class="community-row">
-        <a href="https://ironbelly.app" target="_blank"><img class="community-row-img"
-            alt="Ironbelly" src="assets/images/ironbelly.png" /></a>
-        <div class="community-row-content">
-          <div class="community-row-heading"><a href="https://ironbelly.app" target="_blank">
-              Ironbelly</a></div>
-          <div class="community-row-desc">Grin mobile wallet you’ve deserved.</div>
-          <div class="community-row-category">iOS and Android app</div>
-        </div>
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Ironbelly wallet is discontinued, this change removes its mention from the download page. 
Context: https://forum.grin.mw/t/ironbelly-is-spitting-fire-no-longer/11003