### PR TITLE
Download page update 

### DIFF
--- a/download.html
+++ b/download.html
@@ -91,7 +91,6 @@ layout: default
       We only list community projects, use at your own risk.
     </div>
     <div class="community-content">
-    <!--commented out and reserved for Grim wallet-->
     <!--<div class="community-row">
         <a href="https://github.com/grinfans/Niffler/releases" target="_blank"><img class="community-row-img"
             alt="Niffler" src="assets/images/niffler.png" /></a>

--- a/download.html
+++ b/download.html
@@ -26,62 +26,60 @@ layout: default
       <!-- Tab content -->
       <div id="Windows" class="tabcontent">
         <h3><a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-win-x64.zip">grin-wallet
-            v5.0.3</a></h3>
+            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.3.1/grin-wallet-v5.3.1-win-x86_64.zip">grin-wallet
+            v5.3.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          97CF851C947F1C5F3DC5E78E3756B55CBB27E1DC9EA658C36A4F536B37510A50
+          C33312CC4769A0754B1366EAAF3837D76975C984BACF87AD6446763BDCE73B00
         </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-win-x64.zip">grin
-            v5.1.2</a></h3>
+        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.3.2/grin-v5.3.2-win-x86_64.zip">grin
+            v5.3.2</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          D3480F049D74557415EF6854D831EC07C653502C793C2CB6BBCE51EDAA167C90
-        </div>
+          3FB4F7C64A5D54B61C149CCEE2110C1FC42A2570D88E71955563B222995001BE        </div>
       </div>
 
       <div id="macOS" class="tabcontent">
         <h3><a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-macos.tar.gz">grin-wallet
-            v5.0.3</a></h3>
+            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.3.1/grin-wallet-v5.3.1-macos-x86_64.tar.gz">grin-wallet
+            v5.3.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          8139e8a74ef8dc52ff759566917219dc26fd4eba7f5e182ce20adf1b7216557e
+          9198bd4330877d3121527b2937458e2a7bc0e605994ba97c47059650dc294acb
         </div>
-        <div class="codebox-heading">or with homebrew</div>
+        <!--<div class="codebox-heading">or with homebrew</div>
         <div class="codebox">
           brew install grin-wallet
-        </div>
-        <h3><a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-macos.tar.gz">grin
-            v5.1.2</a></h3>
+        </div>-->
+        <h3><a href="https://github.com/mimblewimble/grin/releases/download/v5.3.2/grin-v5.3.2-macos-x86_64.tar.gz">grin
+            v5.3.2</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          5dc8895554f1a65e2b782e8548fb08418cbad6b0de5bcc78f1ace740bd651cac
-        </div>
-        <div class="codebox-heading">or with homebrew</div>
-        <div class="codebox">
+          d63212477f7c38169fefe3b093f192e9576e9e4dd7d690974065f9c2dc1f031b        </div>
+        <!--<div class="codebox-heading">or with homebrew</div>
+        div class="codebox">
           brew install grin
-        </div>
+        </div>-->
       </div>
 
       <div id="Linux" class="tabcontent">
         <h3> <a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-linux-amd64.tar.gz">grin-wallet
-            v5.0.3</a></h3>
+            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.3.1/grin-wallet-v5.0.3-linux-amd64.tar.gz">grin-wallet
+            v5.3.1</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          4dd24a03be40e91cefdeb2d95a01e009d1b2b1a473beab6a50281fcbfa576f72
-        </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-linux-amd64.tar.gz">grin
-            v5.1.2</a></h3>
+          b2817330e4f6cf96f68dd7f544f6a4d51d570e8dfde306ad5cd8aa087dbef86d        </div>
+        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.3.2/grin-v5.3.2-linux-x86_64.tar.gz">grin
+            v5.3.2</a></h3>
         <div class="codebox-heading">SHA256 HASH:</div>
         <div class="codebox">
-          35de24bb2c1bc6fd250ab57bad3a4740177209cbc2bbd1ca3db8abf216e37705
+          0dd5e4a0456ddf77513198b096eccf0b5e9939be80318ec457e847651ee50f71   
         </div>
-	<div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
+	      
+        <!--<div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
         <div class="codebox">
           snap install grin
-	</div>
+	      </div>-->
       </div>
     </section>
   </div>
@@ -93,7 +91,8 @@ layout: default
       We only list community projects, use at your own risk.
     </div>
     <div class="community-content">
-      <div class="community-row">
+    <!--commented out and reserved for Grim wallet-->
+    <!--<div class="community-row">
         <a href="https://github.com/grinfans/Niffler/releases" target="_blank"><img class="community-row-img"
             alt="Niffler" src="assets/images/niffler.png" /></a>
         <div class="community-row-content">
@@ -102,7 +101,7 @@ layout: default
           <div class="community-row-desc">Grin GUI node and wallet.</div>
           <div class="community-row-category">Windows, Linux and macOS</div>
         </div>
-      </div>
+      </div>-->
       <div class="community-row">
         <a href="https://grinplusplus.github.io" target="_blank"><img class="community-row-img"
             alt="Grin++" src="assets/images/gpp.svg" /></a>
@@ -113,7 +112,7 @@ layout: default
           <div class="community-row-category">Windows, Linux, macOS, and Android</div>
         </div>
       </div>
-      <div class="community-row">
+      <!--<div class="community-row">
         <a href="https://ironbelly.app" target="_blank"><img class="community-row-img"
             alt="Ironbelly" src="assets/images/ironbelly.png" /></a>
         <div class="community-row-content">
@@ -121,7 +120,7 @@ layout: default
               Ironbelly</a></div>
           <div class="community-row-desc">Grin mobile wallet you’ve deserved.</div>
           <div class="community-row-category">iOS and Android app</div>
-        </div>
+        </div>-->
       </div>
     </div>
   </div>


### PR DESCRIPTION
Updated links and SHA256 for grin v.5.3.2 and grin-wallet v5.3.1 on all platforms while removing projects not actively developed from view by commenting out homebrew and snap installs + Niffler and Ironbelly community listings, preserving spots for future projects to use.