### PR TITLE
Remove broken link and update outdated link on main page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
     <div class="footer-links">
         <a href="https://forum.grin.mw">Forum</a>
         <a href="https://keybase.io/team/grincoin">Keybase</a>
-        <a href="https://grinnews.substack.com/">News</a>
+        <a href="https://grinpost.substack.com/">News</a>
         <a href="https://github.com/mimblewimble/grin">Github</a>
         <br>
         <a href="{{ 'policies/code_of_conduct' | relative_url }}">Code of Conduct</a>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ layout: default
         <div class="section-3-text">
           Grin is launched fairly — free of ICO,
           pre-mine or founder’s reward. We rely on donations to keep working on
-          the project. Support the movement by purchasing some <a href="https://tmgox.com/">merch↗</a> or making a
+          the project. Support the movement by making a
           <a href="fund">donation</a>.</div>
       </div>
     </div>


### PR DESCRIPTION
- Main page still links to merch site (https://tmgox.com/) which does not exist.  Removed link and reference to it.

- Footer (which shows on main page) links to 'news' substack (https://grinnews.substack.com/) which had not been updated since 2022.  I updated link to the actively maintained substack (https://grinpost.substack.com/).  If that new link is not appropriate for the main page, let me know and I can re-submit with the 'news' link removed.  I do not recommend leaving the old substack as it make the project look dormant. 

(I will try to make any future pull requests one issue related so they are easy to review/merge-or-reject). 