### PR TITLE
Update stale blog link to active forum link.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
+    rexml
 
 PLATFORMS
   ruby
@@ -68,4 +69,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.17.2
+   2.7.0

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -15,7 +15,7 @@
     <li><a href="{{'community' | relative_url}}">Community</a></li>
     <li><a href="{{'fund' | relative_url}}">Funding</a></li>
     <li><a href="{{'open-research-problems' | relative_url}}">Research</a></li>
-    <li><a href="{{'blog' | relative_url}}">Blog</a></li>
+    <li><a href="https://forum.grin.mw">Forum</a></li>
     <li><a href="https://docs.grin.mw">Docs</a></li>
     <li><a href="https://github.com/mimblewimble/grin">GitHub</a></li>
   </ul>

--- a/download.html
+++ b/download.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<script type="text/javascript" src="/assets/js/download.js"></script>
+<script type="text/javascript" src="./assets/js/download.js"></script>
 <main class="site pad">
   <div class="download">
     <div class="download-heading">


### PR DESCRIPTION
This pull request makes an edit of 'structure' to the website.  Specifically, it removes 'blog' from top menu of the [grin.mw](http://grin.mw/) website. 

**Rational:** The 'blog' tab is prominent and the last post was in Jan 2021.  A visitor could not be blamed for thinking grin was "dead" given that condition. 

**Options:**
1. Start making blog posts (not recommended since it takes a lot of volunteer time from a senior member and would eventually become stale again)
2. Remove 'blog' and replace with 'forum'.  The forum is part of the [grin.mw](http://grin.mw/) domain so it fits.  Additionally, it is 'self maintaining' in that activity happens naturally so visitors would see that things are happening.  (_recommended_).
3. Remove 'blog' and replace it with nothing (acceptable option, but I like 2 better)

This pull request implements option 2.  Let me know if alternate implementation is requested.

**Note:** This pull request "orphans" but does not remove the [blog/index](https://grin.mw/blog/) endpoint and retains the contents of the [_post](https://github.com/mimblewimble/site/tree/master/_posts) directory.  I could remove those and resubmit if requested.