### PR TITLE
Download Links Pull From GitHub API

### DIFF
--- a/_layouts/default-black.html
+++ b/_layouts/default-black.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/favicon-16x16.png">
+    <link rel="manifest" href="{{ site.baseurl }}/site.webmanifest">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/favicon-16x16.png">
+    <link rel="manifest" href="{{ site.baseurl }}/site.webmanifest">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -89,7 +89,7 @@ async function updateReleaseLinks() {
             document.getElementById(elementIds.link).textContent = repoData?.releaseVersion ? `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'} ${repoData.releaseVersion}` : `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'}`;
             
             document.getElementById(elementIds.hash).href = hashUrl;
-            document.getElementById(elementIds.hash).textContent = hashAsset ? 'Link to official GitHub hashfile: sha256sum.txt' : 'See GitHub for official sha256sum.txt hashfile';
+            document.getElementById(elementIds.hash).textContent = hashAsset ? 'Link to GitHub hashfile: sha256sum.txt' : 'See GitHub for official sha256sum.txt hashfile';
         }
 
         ['win', 'macos', 'linux'].forEach(platform => {

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -52,8 +52,8 @@ async function fetchReleaseData(repositoryName) {
 
 async function updateReleaseLinks() {
     try {
-        const walletData = await fetchReleaseData('grin-walletx');
-        const nodeData = await fetchReleaseData('grinx');
+        const walletData = await fetchReleaseData('grin-wallet');
+        const nodeData = await fetchReleaseData('grin');
 
         const links = {
             win: {

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -1,20 +1,16 @@
 function openDownloadTab(evt, cityName) {
-    // Declare all variables
     var i, tabcontent, tablinks;
 
-    // Get all elements with class="tabcontent" and hide them
     tabcontent = document.getElementsByClassName("tabcontent");
     for (i = 0; i < tabcontent.length; i++) {
         tabcontent[i].style.display = "none";
     }
 
-    // Get all elements with class="tablinks" and remove the class "active"
     tablinks = document.getElementsByClassName("tablinks");
     for (i = 0; i < tablinks.length; i++) {
         tablinks[i].className = tablinks[i].className.replace(" active", "");
     }
 
-    // Show the current tab, and add an "active" class to the button that opened the tab
     document.getElementById(cityName).style.display = "block";
     evt.currentTarget.className += " active";
 }
@@ -28,13 +24,105 @@ function getOS() {
     } else if (!os && /Linux/.test(platform)) {
         os = 'linux';
     } else {
-        // show Windows by default
-        os = "windows"
+        os = "windows"; // default to Windows
     }
     return os;
 }
 
-window.onload = function () {
-    os = getOS();
-    document.getElementById(os).click();
+async function fetchReleaseData(repositoryName) {
+    const apiUrl = `https://api.github.com/repos/mimblewimble/${repositoryName}/releases/latest`;
+
+    try {
+        const response = await fetch(apiUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch: ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        return {
+            releaseVersion: data.tag_name,
+            assets: data.assets,
+        };
+    } catch (error) {
+        console.error(`Error fetching release information for ${repositoryName}:`, error);
+        return null;
+    }
 }
+
+async function updateReleaseLinks() {
+    try {
+        const walletData = await fetchReleaseData('grin-walletx');
+        const nodeData = await fetchReleaseData('grinx');
+
+        const links = {
+            win: {
+                Suffix: 'win-x86_64.zip',
+                HashSuffix: 'win-x86_64-sha256sum.txt'
+            },
+            macos: {
+                Suffix: 'macos-x86_64.tar.gz',
+                HashSuffix: 'macos-x86_64-sha256sum.txt'
+            },
+            linux: {
+                Suffix: 'linux-x86_64.tar.gz',
+                HashSuffix: 'linux-x86_64-sha256sum.txt'
+            }
+        };
+
+        function updateLink(platform, type, elementIds, repoData, fallbackUrl) {
+            const suffix = links[platform][`Suffix`];
+            const hashSuffix = links[platform][`HashSuffix`];
+
+            const asset = repoData?.assets?.find(asset => asset.name.endsWith(suffix));
+            const hashAsset = repoData?.assets?.find(asset => asset.name.endsWith(hashSuffix));
+            
+            const downloadUrl = asset ? asset.browser_download_url : fallbackUrl;
+            const hashUrl = hashAsset ? hashAsset.browser_download_url : fallbackUrl;
+
+            document.getElementById(elementIds.link).href = downloadUrl;
+            document.getElementById(elementIds.link).textContent = repoData?.releaseVersion ? `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'} ${repoData.releaseVersion}` : `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'}`;
+            
+            document.getElementById(elementIds.hash).href = hashUrl;
+            document.getElementById(elementIds.hash).textContent = hashAsset ? 'Download hash file from GitHub' : 'Go to GitHub and download sha256sum.txt hash file';
+        }
+
+        ['win', 'macos', 'linux'].forEach(platform => {
+            const walletFallbackUrl = 'https://github.com/mimblewimble/grin-wallet/releases/latest';
+            const nodeFallbackUrl = 'https://github.com/mimblewimble/grin/releases/latest';
+
+            updateLink(platform, 'wallet', { link: `${platform}-wallet-link`, hash: `${platform}-wallet-hash` }, walletData || {}, walletFallbackUrl);
+            updateLink(platform, 'node', { link: `${platform}-node-link`, hash: `${platform}-node-hash` }, nodeData || {}, nodeFallbackUrl);
+        });
+
+    } catch (error) {
+        console.error("Error updating release links:", error);
+
+        // Fallback to default links for wallet and node
+        const walletFallbackUrl = 'https://github.com/mimblewimble/grin-wallet/releases/latest';
+        const nodeFallbackUrl = 'https://github.com/mimblewimble/grin/releases/latest';
+
+        ['win', 'macos', 'linux'].forEach(platform => {
+            document.getElementById(`${platform}-wallet-link`).href = walletFallbackUrl;
+            document.getElementById(`${platform}-wallet-link`).textContent = 'Grin Wallet';
+
+            document.getElementById(`${platform}-wallet-hash`).href = walletFallbackUrl;
+            document.getElementById(`${platform}-wallet-hash`).textContent = 'Go to GitHub and download sha256sum.txt hash file';
+
+            document.getElementById(`${platform}-node-link`).href = nodeFallbackUrl;
+            document.getElementById(`${platform}-node-link`).textContent = 'Grin Node';
+
+            document.getElementById(`${platform}-node-hash`).href = nodeFallbackUrl;
+            document.getElementById(`${platform}-node-hash`).textContent = 'Go to GitHub and download sha256sum.txt hash file';
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    updateReleaseLinks();
+});
+
+window.onload = function () {
+    const os = getOS();
+    document.getElementById(os).click();
+};

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -1,16 +1,20 @@
 function openDownloadTab(evt, cityName) {
+    // Declare all variables
     var i, tabcontent, tablinks;
 
+    // Get all elements with class="tabcontent" and hide them
     tabcontent = document.getElementsByClassName("tabcontent");
     for (i = 0; i < tabcontent.length; i++) {
         tabcontent[i].style.display = "none";
     }
 
+    // Get all elements with class="tablinks" and remove the class "active"
     tablinks = document.getElementsByClassName("tablinks");
     for (i = 0; i < tablinks.length; i++) {
         tablinks[i].className = tablinks[i].className.replace(" active", "");
     }
 
+    // Show the current tab, and add an "active" class to the button that opened the tab
     document.getElementById(cityName).style.display = "block";
     evt.currentTarget.className += " active";
 }
@@ -24,7 +28,8 @@ function getOS() {
     } else if (!os && /Linux/.test(platform)) {
         os = 'linux';
     } else {
-        os = "windows"; // default to Windows
+        // show Windows by default
+        os = "windows";
     }
     return os;
 }

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -89,7 +89,7 @@ async function updateReleaseLinks() {
             document.getElementById(elementIds.link).textContent = repoData?.releaseVersion ? `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'} ${repoData.releaseVersion}` : `${type === 'wallet' ? 'Grin Wallet' : 'Grin Node'}`;
             
             document.getElementById(elementIds.hash).href = hashUrl;
-            document.getElementById(elementIds.hash).textContent = hashAsset ? 'Download hash file from GitHub' : 'Go to GitHub and download sha256sum.txt hash file';
+            document.getElementById(elementIds.hash).textContent = hashAsset ? 'Link to official GitHub hashfile: sha256sum.txt' : 'See GitHub for official sha256sum.txt hashfile';
         }
 
         ['win', 'macos', 'linux'].forEach(platform => {
@@ -112,7 +112,7 @@ async function updateReleaseLinks() {
             document.getElementById(`${platform}-wallet-link`).textContent = 'Grin Wallet';
 
             document.getElementById(`${platform}-wallet-hash`).href = walletFallbackUrl;
-            document.getElementById(`${platform}-wallet-hash`).textContent = 'Go to GitHub and download sha256sum.txt hash file';
+            document.getElementById(`${platform}-wallet-hash`).textContent = 'See GitHub for official sha256sum.txt hashfile';
 
             document.getElementById(`${platform}-node-link`).href = nodeFallbackUrl;
             document.getElementById(`${platform}-node-link`).textContent = 'Grin Node';

--- a/download.html
+++ b/download.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<script type="text/javascript" src="./assets/js/download.js"></script>
+<script type="text/javascript" src="{{ site.baseurl }}/assets/js/download.js"></script>
 <main class="site pad">
   <div class="download">
     <div class="download-heading">
@@ -25,63 +25,63 @@ layout: default
       </div>
       <!-- Tab content -->
       <div id="Windows" class="tabcontent">
-        <h3><a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-win-x64.zip">grin-wallet
-            v5.0.3</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
+        <h3>
+          <a id="win-wallet-link" href="#">grin-wallet</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          97CF851C947F1C5F3DC5E78E3756B55CBB27E1DC9EA658C36A4F536B37510A50
+          <a id="win-wallet-hash" href="#">Download Hash File</a>
         </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-win-x64.zip">grin
-            v5.1.2</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
+
+        <h3>
+          <a id="win-node-link" href="#">grin</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          D3480F049D74557415EF6854D831EC07C653502C793C2CB6BBCE51EDAA167C90
+          <a id="win-node-hash" href="#">Download Hash File</a>
         </div>
       </div>
 
       <div id="macOS" class="tabcontent">
-        <h3><a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-macos.tar.gz">grin-wallet
-            v5.0.3</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
+        <h3>
+          <a id="macos-wallet-link" href="#">grin-wallet</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          8139e8a74ef8dc52ff759566917219dc26fd4eba7f5e182ce20adf1b7216557e
+          <a id="macos-wallet-hash" href="#">Download Hash File</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
+        <div class="codebox">brew install grin-wallet</div>
+
+        <h3>
+          <a id="macos-node-link" href="#">grin</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          brew install grin-wallet
-        </div>
-        <h3><a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-macos.tar.gz">grin
-            v5.1.2</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
-        <div class="codebox">
-          5dc8895554f1a65e2b782e8548fb08418cbad6b0de5bcc78f1ace740bd651cac
+          <a id="macos-node-hash" href="#">Download Hash File</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
-        <div class="codebox">
-          brew install grin
-        </div>
+        <div class="codebox">brew install grin</div>
       </div>
 
       <div id="Linux" class="tabcontent">
-        <h3> <a
-            href="https://github.com/mimblewimble/grin-wallet/releases/download/v5.0.3/grin-wallet-v5.0.3-linux-amd64.tar.gz">grin-wallet
-            v5.0.3</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
+        <h3>
+          <a id="linux-wallet-link" href="#">grin-wallet</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          4dd24a03be40e91cefdeb2d95a01e009d1b2b1a473beab6a50281fcbfa576f72
+          <a id="linux-wallet-hash" href="#">Download Hash File</a>
         </div>
-        <h3> <a href="https://github.com/mimblewimble/grin/releases/download/v5.1.2/grin-v5.1.2-linux-amd64.tar.gz">grin
-            v5.1.2</a></h3>
-        <div class="codebox-heading">SHA256 HASH:</div>
+
+        <h3>
+          <a id="linux-node-link" href="#">grin</a>
+        </h3>
+        <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          35de24bb2c1bc6fd250ab57bad3a4740177209cbc2bbd1ca3db8abf216e37705
+          <a id="linux-node-hash" href="#">Download Hash File</a>
         </div>
-	<div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
-        <div class="codebox">
-          snap install grin
-	</div>
+        <div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
+        <div class="codebox">snap install grin</div>
       </div>
     </section>
   </div>

--- a/download.html
+++ b/download.html
@@ -26,7 +26,7 @@ layout: default
       <!-- Tab content -->
       <div id="Windows" class="tabcontent">
         <h3>
-          <a id="win-wallet-link" href="https://github.com/mimblewimble/grin-wallet/releases/latest">c</a>
+          <a id="win-wallet-link" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Grin Wallet</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">

--- a/download.html
+++ b/download.html
@@ -26,7 +26,7 @@ layout: default
       <!-- Tab content -->
       <div id="Windows" class="tabcontent">
         <h3>
-          <a id="win-wallet-link" href="#">grin-wallet</a>
+          <a id="win-wallet-link" href="#">c</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
@@ -34,7 +34,7 @@ layout: default
         </div>
 
         <h3>
-          <a id="win-node-link" href="#">grin</a>
+          <a id="win-node-link" href="#">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
@@ -44,7 +44,7 @@ layout: default
 
       <div id="macOS" class="tabcontent">
         <h3>
-          <a id="macos-wallet-link" href="#">grin-wallet</a>
+          <a id="macos-wallet-link" href="#">Grin Wallet</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
@@ -54,7 +54,7 @@ layout: default
         <div class="codebox">brew install grin-wallet</div>
 
         <h3>
-          <a id="macos-node-link" href="#">grin</a>
+          <a id="macos-node-link" href="#">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
@@ -66,7 +66,7 @@ layout: default
 
       <div id="Linux" class="tabcontent">
         <h3>
-          <a id="linux-wallet-link" href="#">grin-wallet</a>
+          <a id="linux-wallet-link" href="#">Grin Wallet</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
@@ -74,7 +74,7 @@ layout: default
         </div>
 
         <h3>
-          <a id="linux-node-link" href="#">grin</a>
+          <a id="linux-node-link" href="#">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">

--- a/download.html
+++ b/download.html
@@ -30,7 +30,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="win-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="win-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
 
         <h3>
@@ -38,7 +38,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="win-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="win-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
       </div>
 
@@ -48,7 +48,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="macos-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="macos-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
         <div class="codebox">brew install grin-wallet</div>
@@ -58,7 +58,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="macos-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="macos-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
         <div class="codebox">brew install grin</div>
@@ -70,7 +70,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="linux-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="linux-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
 
         <h3>
@@ -78,7 +78,7 @@ layout: default
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="linux-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
+          <a id="linux-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">See GitHub for official sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
         <div class="codebox">snap install grin</div>

--- a/download.html
+++ b/download.html
@@ -26,39 +26,39 @@ layout: default
       <!-- Tab content -->
       <div id="Windows" class="tabcontent">
         <h3>
-          <a id="win-wallet-link" href="#">c</a>
+          <a id="win-wallet-link" href="https://github.com/mimblewimble/grin-wallet/releases/latest">c</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="win-wallet-hash" href="#">Download Hash File</a>
+          <a id="win-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
 
         <h3>
-          <a id="win-node-link" href="#">Grin Node</a>
+          <a id="win-node-link" href="https://github.com/mimblewimble/grin/releases/latest">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="win-node-hash" href="#">Download Hash File</a>
+          <a id="win-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
       </div>
 
       <div id="macOS" class="tabcontent">
         <h3>
-          <a id="macos-wallet-link" href="#">Grin Wallet</a>
+          <a id="macos-wallet-link" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Grin Wallet</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="macos-wallet-hash" href="#">Download Hash File</a>
+          <a id="macos-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
         <div class="codebox">brew install grin-wallet</div>
 
         <h3>
-          <a id="macos-node-link" href="#">Grin Node</a>
+          <a id="macos-node-link" href="https://github.com/mimblewimble/grin/releases/latest">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="macos-node-hash" href="#">Download Hash File</a>
+          <a id="macos-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or with homebrew</div>
         <div class="codebox">brew install grin</div>
@@ -66,19 +66,19 @@ layout: default
 
       <div id="Linux" class="tabcontent">
         <h3>
-          <a id="linux-wallet-link" href="#">Grin Wallet</a>
+          <a id="linux-wallet-link" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Grin Wallet</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="linux-wallet-hash" href="#">Download Hash File</a>
+          <a id="linux-wallet-hash" href="https://github.com/mimblewimble/grin-wallet/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
 
         <h3>
-          <a id="linux-node-link" href="#">Grin Node</a>
+          <a id="linux-node-link" href="https://github.com/mimblewimble/grin/releases/latest">Grin Node</a>
         </h3>
         <div class="codebox-heading">SHA256 HASH FILE:</div>
         <div class="codebox">
-          <a id="linux-node-hash" href="#">Download Hash File</a>
+          <a id="linux-node-hash" href="https://github.com/mimblewimble/grin/releases/latest">Go to GitHub and download sha256sum.txt hash file</a>
         </div>
         <div class="codebox-heading">or using <a href="https://snapcraft.io/grin">snap</a> install grin and grin-wallet with one command</div>
         <div class="codebox">snap install grin</div>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@ layout: default
         Designed for the decades to come, not just for tomorrow. To be used by anyone, anywhere.
       </p>
       <div class="section-2-start-download">
-        <a class="btn btn-bright btn-home" href="/get-started">Get Started</a>
-        <a class="btn btn-light btn-home" href="/download">Download</a>
+        <a class="btn btn-bright btn-home" href="{{ site.baseurl }}/get-started">Get Started</a>
+        <a class="btn btn-light btn-home" href="{{ site.baseurl }}/download">Download</a>
       </div>
       <span class="section-1-star">*</span>
     </div>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "./android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "./android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }


### PR DESCRIPTION
**Download links:**
This pull request provides a download.js file update that will get the grin-wallet and grin versions from the github latest release API and update the links on the download.html.  The download links will now always be up to date.  If the API fails for any reason, the links default to the github latest release page.  That is less good because they have to find the file they need, but it is still better because it won't cause confusion as to what the latest link is.

**Hashfiles**
I initially tried to make it so that the js also extracted the hash from the github txt hashfile file and displayed the hash on the page where the hash used to be provided.  However, it turns out that browsers will not let you open (read from) a txt file pulled from a different domain then the main site (security).  So, instead I have it link to the GitHub sha.txt file for each download.  If the API fails it will, like the download link, default to a direct link to the github latest release page.

**site.baseurl**
Final edit:  The repo currently assumes the site will be mounted at a domains base address (eg. mimblewimble.github.io).  However, some hard coded links break when a fork of the repo is tested on a users clone site at something other than the base level (eg. mimblewimble.github.io/site/).  Several links were updated to become flexible for testing on forks [eg. adding {{ site.baseurl }} or using "./" in place of "/". ]  

Note:  There is a need to update some of the community GUI links on the bottom of the page (e.g. add grim) but that is not addressed in this pull request.