### PR TITLE
Update donation address links

### DIFF
--- a/fund.html
+++ b/fund.html
@@ -7,7 +7,7 @@ layout: default-black
     <div class="fund-heading">
       <span>GRIN GENERAL FUND</span>
       <h1 id="funding-amount"></h1>
-      <small><a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/reports/funding_transparency_2023Q1.md">2023 Q1 Transparency Report↗</a></small>
+      <small><a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/reports/funding_transparency_2024Q4.md">2024 Q4 Transparency Report↗</a></small>
     </div>
     <p>
       Grin is strictly non-profit. To keep Grin open and free from controlling influences, the project relies 100% on community donations for its funding needs. We ask any person, corporate entity or institution who sees potential in Grin/Mimblewimble technology to consider donating to the project. We hope that the vibrant cryptocurrency community will help Grin to achieve its goal of providing a reliable, scalable and privacy-driven blockchain implementation that truly belongs to everyone.
@@ -15,10 +15,6 @@ layout: default-black
       Donate to the General Fund to be included on the <a href="/friends">Friends of Grin</a> page.
     </p>
     <h3>Donate now</h3>
-    <small class="fund-donation-type">GRIN</small>
-    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#grin" class="fund-address">Donation address in /grin-pm repo</a>
-    <small class="fund-donation-type">BITCOIN LEGACY</small>
-    <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#legacy" class="fund-address">Donation address in /grin-pm repo</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>
     <a href="https://github.com/mimblewimble/grin-pm/blob/master/financials/addresses.md#segwit" class="fund-address">Donation address in /grin-pm repo</a>
 


### PR DESCRIPTION
* Removes legacy donation options
* Keeps only the Bitcoin SegWit donation option
* Updates the transparency report link from 2023 Q1 to 2024 Q4 (which will be merged soon)