### PR TITLE
Added link to grin.mw/open-research-problems to navbar

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -14,6 +14,7 @@
     <li><a href="{{'download' | relative_url}}">Download</a></li>
     <li><a href="{{'community' | relative_url}}">Community</a></li>
     <li><a href="{{'fund' | relative_url}}">Funding</a></li>
+    <li><a href="https://grin.mw/open-research-problems">Research</a></li>
     <li><a href="https://docs.grin.mw">Docs</a></li>
     <li><a href="https://github.com/mimblewimble/grin">GitHub</a></li>
     <li><a href="https://grincc.mw">GrinCC</a></li>


### PR DESCRIPTION
There was no link to the research page anywhere on the site so I added it to the navbar.